### PR TITLE
Service waf enable

### DIFF
--- a/fastly/client.go
+++ b/fastly/client.go
@@ -190,7 +190,7 @@ func (c *Client) Delete(p string, ro *RequestOptions) (*http.Response, error) {
 	return c.Request("DELETE", p, ro)
 }
 
-// DeleteNew issues an HTTP DELETE request.
+// DeleteJSON issues an HTTP DELETE request.
 func (c *Client) DeleteJSON(p string, i interface{}, ro *RequestOptions) (*http.Response, error) {
 	return c.RequestJSONAPI("DELETE", p, i, ro)
 }

--- a/fastly/client.go
+++ b/fastly/client.go
@@ -190,6 +190,11 @@ func (c *Client) Delete(p string, ro *RequestOptions) (*http.Response, error) {
 	return c.Request("DELETE", p, ro)
 }
 
+// DeleteNew issues an HTTP DELETE request.
+func (c *Client) DeleteJSON(p string, i interface{}, ro *RequestOptions) (*http.Response, error) {
+	return c.RequestJSONAPI("DELETE", p, i, ro)
+}
+
 // Request makes an HTTP request against the HTTPClient using the given verb,
 // Path, and request options.
 func (c *Client) Request(verb, p string, ro *RequestOptions) (*http.Response, error) {

--- a/fastly/fixtures/wafs/cleanup.yaml
+++ b/fastly/fixtures/wafs/cleanup.yaml
@@ -1,40 +1,41 @@
 ---
 version: 1
-rwmutex: {}
 interactions:
 - request:
-    body: ""
+    body: |
+      {"data":{"type":"waf_firewall","id":"0MjXWp60xLZ3zwM6LlNoeU","attributes":{"service_version_number":"2"}}}
     form: {}
     headers:
-      Fastly-Key:
-      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+      Accept:
+      - application/vnd.api+json
+      Content-Type:
+      - application/vnd.api+json
       User-Agent:
-      - FastlyGo/0.4.3.dev (+github.com/fastly/go-fastly; go1.12)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/54/wafs/2WK9ofHfHcPi3s6S2X0Z8m
+      - FastlyGo/1.3.0 (+github.com/fastly/go-fastly; go1.13.3)
+    url: https://api.fastly.com/waf/firewalls/0MjXWp60xLZ3zwM6LlNoeU
     method: DELETE
   response:
-    body: ""
+    body: '{"errors":[{"title":"Resource not found","detail":"We could not find a
+      resource matching the one in your request"}]}'
     headers:
       Accept-Ranges:
       - bytes
       Date:
-      - Sat, 11 May 2019 21:45:03 GMT
+      - Mon, 11 Nov 2019 09:47:14 GMT
       Status:
-      - 204 No Content
+      - 404 Not Found
       Strict-Transport-Security:
       - max-age=31536000
       Via:
-      - 1.1 varnish
       - 1.1 varnish
       X-Cache:
       - MISS, MISS
       X-Cache-Hits:
       - 0, 0
-      X-Content-Type-Options:
-      - nosniff
       X-Served-By:
-      - cache-control-slwdc9035-CONTROL-SLWDC, cache-lax8631-LAX
+      - cache-control-slwdc9037-CONTROL-SLWDC, cache-lcy19247-LCY
       X-Timer:
-      - S1557611103.468691,VS0,VE153
-    status: 204 No Content
-    code: 204
+      - S1573465634.082945,VS0,VE131
+    status: 404 Not Found
+    code: 404
+    duration: ""

--- a/fastly/fixtures/wafs/cleanup.yaml
+++ b/fastly/fixtures/wafs/cleanup.yaml
@@ -3,7 +3,7 @@ version: 1
 interactions:
 - request:
     body: |
-      {"data":{"type":"waf_firewall","id":"0MjXWp60xLZ3zwM6LlNoeU","attributes":{"service_version_number":"2"}}}
+      {"data":{"type":"waf_firewall","id":"59onHkuKX28AMcf0gOojis","attributes":{"service_version_number":"2"}}}
     form: {}
     headers:
       Accept:
@@ -11,8 +11,8 @@ interactions:
       Content-Type:
       - application/vnd.api+json
       User-Agent:
-      - FastlyGo/1.3.0 (+github.com/fastly/go-fastly; go1.13.3)
-    url: https://api.fastly.com/waf/firewalls/0MjXWp60xLZ3zwM6LlNoeU
+      - FastlyGo/1.3.0 (+github.com/fastly/go-fastly; go1.13.4)
+    url: https://api.fastly.com/waf/firewalls/59onHkuKX28AMcf0gOojis
     method: DELETE
   response:
     body: '{"errors":[{"title":"Resource not found","detail":"We could not find a
@@ -21,7 +21,7 @@ interactions:
       Accept-Ranges:
       - bytes
       Date:
-      - Mon, 11 Nov 2019 09:47:14 GMT
+      - Tue, 12 Nov 2019 16:10:25 GMT
       Status:
       - 404 Not Found
       Strict-Transport-Security:
@@ -33,9 +33,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9037-CONTROL-SLWDC, cache-lcy19247-LCY
+      - cache-control-slwdc9036-CONTROL-SLWDC, cache-lcy19279-LCY
       X-Timer:
-      - S1573465634.082945,VS0,VE131
+      - S1573575025.472733,VS0,VE128
     status: 404 Not Found
     code: 404
     duration: ""

--- a/fastly/fixtures/wafs/condition/cleanup.yaml
+++ b/fastly/fixtures/wafs/condition/cleanup.yaml
@@ -1,16 +1,13 @@
 ---
 version: 1
-rwmutex: {}
 interactions:
 - request:
     body: ""
     form: {}
     headers:
-      Fastly-Key:
-      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
-      - FastlyGo/0.4.3.dev (+github.com/fastly/go-fastly; go1.12)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/54/condition/test-waf-condition
+      - FastlyGo/1.3.0 (+github.com/fastly/go-fastly; go1.13.3)
+    url: https://api.fastly.com/service/3hn15tWwwLhD47TJAYqj3C/version/2/condition/WAF_Prefetch
     method: DELETE
   response:
     body: '{"status":"ok"}'
@@ -22,11 +19,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sat, 11 May 2019 21:45:04 GMT
+      - Mon, 11 Nov 2019 09:47:14 GMT
       Fastly-Ratelimit-Remaining:
-      - "985"
+      - "991"
       Fastly-Ratelimit-Reset:
-      - "1557612000"
+      - "1573466400"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -35,14 +32,14 @@ interactions:
       - Accept-Encoding
       Via:
       - 1.1 varnish
-      - 1.1 varnish
       X-Cache:
       - MISS, MISS
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9035-CONTROL-SLWDC, cache-lax8631-LAX
+      - cache-control-slwdc9037-CONTROL-SLWDC, cache-lcy19247-LCY
       X-Timer:
-      - S1557611104.983094,VS0,VE264
+      - S1573465635.592489,VS0,VE276
     status: 200 OK
     code: 200
+    duration: ""

--- a/fastly/fixtures/wafs/condition/cleanup.yaml
+++ b/fastly/fixtures/wafs/condition/cleanup.yaml
@@ -6,8 +6,8 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/1.3.0 (+github.com/fastly/go-fastly; go1.13.3)
-    url: https://api.fastly.com/service/3hn15tWwwLhD47TJAYqj3C/version/2/condition/WAF_Prefetch
+      - FastlyGo/1.3.0 (+github.com/fastly/go-fastly; go1.13.4)
+    url: https://api.fastly.com/service/6gkEdARZ3mPzhQvdi2YH3j/version/2/condition/WAF_Prefetch
     method: DELETE
   response:
     body: '{"status":"ok"}'
@@ -19,11 +19,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 11 Nov 2019 09:47:14 GMT
+      - Tue, 12 Nov 2019 16:10:26 GMT
       Fastly-Ratelimit-Remaining:
-      - "991"
+      - "969"
       Fastly-Ratelimit-Reset:
-      - "1573466400"
+      - "1573578000"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -37,9 +37,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9037-CONTROL-SLWDC, cache-lcy19247-LCY
+      - cache-control-slwdc9035-CONTROL-SLWDC, cache-lcy19279-LCY
       X-Timer:
-      - S1573465635.592489,VS0,VE276
+      - S1573575026.978734,VS0,VE248
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/wafs/condition/create.yaml
+++ b/fastly/fixtures/wafs/condition/create.yaml
@@ -1,16 +1,15 @@
 ---
 version: 1
-rwmutex: {}
 interactions:
 - request:
-    body: Service=7i6HN3TK9wS159v2gPAZ8A&Version=54&name=test-waf-condition&priority=1&statement=req.url~%2B%22index.html%22&type=PREFETCH
+    body: Service=3hn15tWwwLhD47TJAYqj3C&Version=2&name=WAF_Prefetch&priority=1&statement=req.url~%2B%22index.html%22&type=PREFETCH
     form:
       Service:
-      - 7i6HN3TK9wS159v2gPAZ8A
+      - 3hn15tWwwLhD47TJAYqj3C
       Version:
-      - "54"
+      - "2"
       name:
-      - test-waf-condition
+      - WAF_Prefetch
       priority:
       - "1"
       statement:
@@ -20,14 +19,12 @@ interactions:
     headers:
       Content-Type:
       - application/x-www-form-urlencoded
-      Fastly-Key:
-      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
-      - FastlyGo/0.4.3.dev (+github.com/fastly/go-fastly; go1.12)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/54/condition
+      - FastlyGo/1.3.0 (+github.com/fastly/go-fastly; go1.13.3)
+    url: https://api.fastly.com/service/3hn15tWwwLhD47TJAYqj3C/version/2/condition
     method: POST
   response:
-    body: '{"name":"test-waf-condition","priority":"1","statement":"req.url~+\"index.html\"","type":"PREFETCH","service_id":"7i6HN3TK9wS159v2gPAZ8A","version":"54","created_at":"2019-05-11T21:44:59Z","updated_at":"2019-05-11T21:44:59Z","deleted_at":null,"comment":""}'
+    body: '{"name":"WAF_Prefetch","priority":"1","statement":"req.url~+\"index.html\"","type":"PREFETCH","service_id":"3hn15tWwwLhD47TJAYqj3C","version":"2","updated_at":"2019-11-11T09:47:09Z","deleted_at":null,"created_at":"2019-11-11T09:47:09Z","comment":""}'
     headers:
       Accept-Ranges:
       - bytes
@@ -36,11 +33,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sat, 11 May 2019 21:44:59 GMT
+      - Mon, 11 Nov 2019 09:47:09 GMT
       Fastly-Ratelimit-Remaining:
-      - "990"
+      - "996"
       Fastly-Ratelimit-Reset:
-      - "1557612000"
+      - "1573466400"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -49,14 +46,14 @@ interactions:
       - Accept-Encoding
       Via:
       - 1.1 varnish
-      - 1.1 varnish
       X-Cache:
       - MISS, MISS
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9037-CONTROL-SLWDC, cache-lax8631-LAX
+      - cache-control-slwdc9035-CONTROL-SLWDC, cache-lcy19247-LCY
       X-Timer:
-      - S1557611099.476242,VS0,VE199
+      - S1573465629.382116,VS0,VE179
     status: 200 OK
     code: 200
+    duration: ""

--- a/fastly/fixtures/wafs/condition/create.yaml
+++ b/fastly/fixtures/wafs/condition/create.yaml
@@ -2,10 +2,10 @@
 version: 1
 interactions:
 - request:
-    body: Service=3hn15tWwwLhD47TJAYqj3C&Version=2&name=WAF_Prefetch&priority=1&statement=req.url~%2B%22index.html%22&type=PREFETCH
+    body: Service=6gkEdARZ3mPzhQvdi2YH3j&Version=2&name=WAF_Prefetch&priority=1&statement=req.url~%2B%22index.html%22&type=PREFETCH
     form:
       Service:
-      - 3hn15tWwwLhD47TJAYqj3C
+      - 6gkEdARZ3mPzhQvdi2YH3j
       Version:
       - "2"
       name:
@@ -20,11 +20,11 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - FastlyGo/1.3.0 (+github.com/fastly/go-fastly; go1.13.3)
-    url: https://api.fastly.com/service/3hn15tWwwLhD47TJAYqj3C/version/2/condition
+      - FastlyGo/1.3.0 (+github.com/fastly/go-fastly; go1.13.4)
+    url: https://api.fastly.com/service/6gkEdARZ3mPzhQvdi2YH3j/version/2/condition
     method: POST
   response:
-    body: '{"name":"WAF_Prefetch","priority":"1","statement":"req.url~+\"index.html\"","type":"PREFETCH","service_id":"3hn15tWwwLhD47TJAYqj3C","version":"2","updated_at":"2019-11-11T09:47:09Z","deleted_at":null,"created_at":"2019-11-11T09:47:09Z","comment":""}'
+    body: '{"name":"WAF_Prefetch","priority":"1","statement":"req.url~+\"index.html\"","type":"PREFETCH","service_id":"6gkEdARZ3mPzhQvdi2YH3j","version":"2","comment":"","deleted_at":null,"updated_at":"2019-11-12T16:10:22Z","created_at":"2019-11-12T16:10:22Z"}'
     headers:
       Accept-Ranges:
       - bytes
@@ -33,11 +33,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 11 Nov 2019 09:47:09 GMT
+      - Tue, 12 Nov 2019 16:10:22 GMT
       Fastly-Ratelimit-Remaining:
-      - "996"
+      - "974"
       Fastly-Ratelimit-Reset:
-      - "1573466400"
+      - "1573578000"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -51,9 +51,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9035-CONTROL-SLWDC, cache-lcy19247-LCY
+      - cache-control-slwdc9037-CONTROL-SLWDC, cache-lcy19279-LCY
       X-Timer:
-      - S1573465629.382116,VS0,VE179
+      - S1573575022.958487,VS0,VE181
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/wafs/create.yaml
+++ b/fastly/fixtures/wafs/create.yaml
@@ -1,39 +1,35 @@
 ---
 version: 1
-rwmutex: {}
 interactions:
 - request:
     body: |
-      {"data":{"type":"waf","attributes":{"prefetch_condition":"test-waf-condition","response":"test-response-object"}}}
+      {"data":{"type":"waf_firewall","attributes":{"prefetch_condition":"WAF_Prefetch","response":"WAf_Response","service_id":"3hn15tWwwLhD47TJAYqj3C","service_version_number":"2"}}}
     form: {}
     headers:
       Accept:
       - application/vnd.api+json
       Content-Type:
       - application/vnd.api+json
-      Fastly-Key:
-      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
-      - FastlyGo/0.4.3.dev (+github.com/fastly/go-fastly; go1.12)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/54/wafs
+      - FastlyGo/1.3.0 (+github.com/fastly/go-fastly; go1.13.3)
+    url: https://api.fastly.com/waf/firewalls
     method: POST
   response:
-    body: '{"data":{"id":"2WK9ofHfHcPi3s6S2X0Z8m","type":"waf","attributes":{"last_push":null,"prefetch_condition":"test-waf-condition","response":"test-response-object","version":54,"service_id":"7i6HN3TK9wS159v2gPAZ8A","disabled":false,"rule_statuses_log_count":0,"rule_statuses_block_count":0,"rule_statuses_disabled_count":0},"relationships":{"configuration_set":{"data":{"id":"3vnl3cwPda9Q3WYCDRuGW","type":"configuration_set"}},"owasp":{"data":{"id":"4Jh5ZWRaYGgPdCdgQZNzyk","type":"owasp"}}}}}'
+    body: '{"data":{"id":"0MjXWp60xLZ3zwM6LlNoeU","type":"waf_firewall","attributes":{"service_id":"3hn15tWwwLhD47TJAYqj3C","prefetch_condition":"WAF_Prefetch","response":"WAf_Response","disabled":false,"service_version_number":2,"created_at":"2019-11-11T09:47:10Z","updated_at":"2019-11-11T09:47:10Z","active_rules_trustwave_log_count":0,"active_rules_trustwave_block_count":0,"active_rules_fastly_log_count":0,"active_rules_fastly_block_count":0,"active_rules_owasp_log_count":0,"active_rules_owasp_block_count":0,"active_rules_owasp_score_count":0}}}'
     headers:
       Accept-Ranges:
       - bytes
       Content-Length:
-      - "489"
+      - "542"
       Content-Type:
       - application/vnd.api+json
       Date:
-      - Sat, 11 May 2019 21:45:00 GMT
+      - Mon, 11 Nov 2019 09:47:10 GMT
       Status:
-      - 200 OK
+      - 201 Created
       Strict-Transport-Security:
       - max-age=31536000
       Via:
-      - 1.1 varnish
       - 1.1 varnish
       X-Cache:
       - MISS, MISS
@@ -42,8 +38,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Served-By:
-      - cache-control-slwdc9035-CONTROL-SLWDC, cache-lax8631-LAX
+      - cache-control-slwdc9036-CONTROL-SLWDC, cache-lcy19247-LCY
       X-Timer:
-      - S1557611100.058242,VS0,VE742
-    status: 200 OK
-    code: 200
+      - S1573465630.989062,VS0,VE868
+    status: 201 Created
+    code: 201
+    duration: ""

--- a/fastly/fixtures/wafs/create.yaml
+++ b/fastly/fixtures/wafs/create.yaml
@@ -3,7 +3,7 @@ version: 1
 interactions:
 - request:
     body: |
-      {"data":{"type":"waf_firewall","attributes":{"prefetch_condition":"WAF_Prefetch","response":"WAf_Response","service_id":"3hn15tWwwLhD47TJAYqj3C","service_version_number":"2"}}}
+      {"data":{"type":"waf_firewall","attributes":{"prefetch_condition":"WAF_Prefetch","response":"WAf_Response","service_id":"6gkEdARZ3mPzhQvdi2YH3j","service_version_number":"2"}}}
     form: {}
     headers:
       Accept:
@@ -11,11 +11,11 @@ interactions:
       Content-Type:
       - application/vnd.api+json
       User-Agent:
-      - FastlyGo/1.3.0 (+github.com/fastly/go-fastly; go1.13.3)
+      - FastlyGo/1.3.0 (+github.com/fastly/go-fastly; go1.13.4)
     url: https://api.fastly.com/waf/firewalls
     method: POST
   response:
-    body: '{"data":{"id":"0MjXWp60xLZ3zwM6LlNoeU","type":"waf_firewall","attributes":{"service_id":"3hn15tWwwLhD47TJAYqj3C","prefetch_condition":"WAF_Prefetch","response":"WAf_Response","disabled":false,"service_version_number":2,"created_at":"2019-11-11T09:47:10Z","updated_at":"2019-11-11T09:47:10Z","active_rules_trustwave_log_count":0,"active_rules_trustwave_block_count":0,"active_rules_fastly_log_count":0,"active_rules_fastly_block_count":0,"active_rules_owasp_log_count":0,"active_rules_owasp_block_count":0,"active_rules_owasp_score_count":0}}}'
+    body: '{"data":{"id":"59onHkuKX28AMcf0gOojis","type":"waf_firewall","attributes":{"service_id":"6gkEdARZ3mPzhQvdi2YH3j","prefetch_condition":"WAF_Prefetch","response":"WAf_Response","disabled":false,"service_version_number":2,"created_at":"2019-11-12T16:10:23Z","updated_at":"2019-11-12T16:10:23Z","active_rules_trustwave_log_count":0,"active_rules_trustwave_block_count":0,"active_rules_fastly_log_count":0,"active_rules_fastly_block_count":0,"active_rules_owasp_log_count":0,"active_rules_owasp_block_count":0,"active_rules_owasp_score_count":0}}}'
     headers:
       Accept-Ranges:
       - bytes
@@ -24,7 +24,7 @@ interactions:
       Content-Type:
       - application/vnd.api+json
       Date:
-      - Mon, 11 Nov 2019 09:47:10 GMT
+      - Tue, 12 Nov 2019 16:10:23 GMT
       Status:
       - 201 Created
       Strict-Transport-Security:
@@ -38,9 +38,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Served-By:
-      - cache-control-slwdc9036-CONTROL-SLWDC, cache-lcy19247-LCY
+      - cache-control-slwdc9036-CONTROL-SLWDC, cache-lcy19279-LCY
       X-Timer:
-      - S1573465630.989062,VS0,VE868
+      - S1573575023.603740,VS0,VE737
     status: 201 Created
     code: 201
     duration: ""

--- a/fastly/fixtures/wafs/create_service.yaml
+++ b/fastly/fixtures/wafs/create_service.yaml
@@ -2,19 +2,21 @@
 version: 1
 interactions:
 - request:
-    body: Service=3hn15tWwwLhD47TJAYqj3C
+    body: comment=go-fastly+client+test&name=test_service_service
     form:
-      Service:
-      - 3hn15tWwwLhD47TJAYqj3C
+      comment:
+      - go-fastly client test
+      name:
+      - test_service_service
     headers:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
       - FastlyGo/1.3.0 (+github.com/fastly/go-fastly; go1.13.3)
-    url: https://api.fastly.com/service/3hn15tWwwLhD47TJAYqj3C/version
+    url: https://api.fastly.com/service
     method: POST
   response:
-    body: '{"service_id":"3hn15tWwwLhD47TJAYqj3C","number":2}'
+    body: '{"customer_id":"WpqWFjTA4lk2N1g0GY2HH","comment":"go-fastly client test","name":"test_service_service","versions":[{"comment":"","staging":false,"number":1,"deleted_at":null,"active":false,"created_at":"2019-11-11T09:47:08Z","testing":false,"service_id":"3hn15tWwwLhD47TJAYqj3C","updated_at":"2019-11-11T09:47:08Z","deployed":false,"locked":false}],"publish_key":"fe546bc09e3ec8138425eb0c34d57454f2c65b13","created_at":"2019-11-11T09:47:08Z","deleted_at":null,"type":"vcl","id":"3hn15tWwwLhD47TJAYqj3C","updated_at":"2019-11-11T09:47:08Z"}'
     headers:
       Accept-Ranges:
       - bytes
@@ -25,7 +27,7 @@ interactions:
       Date:
       - Mon, 11 Nov 2019 09:47:08 GMT
       Fastly-Ratelimit-Remaining:
-      - "998"
+      - "999"
       Fastly-Ratelimit-Reset:
       - "1573466400"
       Status:
@@ -43,7 +45,7 @@ interactions:
       X-Served-By:
       - cache-control-slwdc9035-CONTROL-SLWDC, cache-lcy19247-LCY
       X-Timer:
-      - S1573465628.248996,VS0,VE391
+      - S1573465628.949339,VS0,VE275
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/wafs/create_service.yaml
+++ b/fastly/fixtures/wafs/create_service.yaml
@@ -12,11 +12,11 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - FastlyGo/1.3.0 (+github.com/fastly/go-fastly; go1.13.3)
+      - FastlyGo/1.3.0 (+github.com/fastly/go-fastly; go1.13.4)
     url: https://api.fastly.com/service
     method: POST
   response:
-    body: '{"customer_id":"WpqWFjTA4lk2N1g0GY2HH","comment":"go-fastly client test","name":"test_service_service","versions":[{"comment":"","staging":false,"number":1,"deleted_at":null,"active":false,"created_at":"2019-11-11T09:47:08Z","testing":false,"service_id":"3hn15tWwwLhD47TJAYqj3C","updated_at":"2019-11-11T09:47:08Z","deployed":false,"locked":false}],"publish_key":"fe546bc09e3ec8138425eb0c34d57454f2c65b13","created_at":"2019-11-11T09:47:08Z","deleted_at":null,"type":"vcl","id":"3hn15tWwwLhD47TJAYqj3C","updated_at":"2019-11-11T09:47:08Z"}'
+    body: '{"customer_id":"WpqWFjTA4lk2N1g0GY2HH","comment":"go-fastly client test","name":"test_service_service","publish_key":"3b94816c86b3a740fe97cbfa2c1f24d00a3317d8","deleted_at":null,"created_at":"2019-11-12T16:10:20Z","updated_at":"2019-11-12T16:10:20Z","id":"6gkEdARZ3mPzhQvdi2YH3j","type":"vcl","versions":[{"service_id":"6gkEdARZ3mPzhQvdi2YH3j","deployed":false,"staging":false,"active":false,"updated_at":"2019-11-12T16:10:20Z","created_at":"2019-11-12T16:10:20Z","locked":false,"deleted_at":null,"testing":false,"number":1,"comment":""}]}'
     headers:
       Accept-Ranges:
       - bytes
@@ -25,11 +25,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 11 Nov 2019 09:47:08 GMT
+      - Tue, 12 Nov 2019 16:10:20 GMT
       Fastly-Ratelimit-Remaining:
-      - "999"
+      - "977"
       Fastly-Ratelimit-Reset:
-      - "1573466400"
+      - "1573578000"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -43,9 +43,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9035-CONTROL-SLWDC, cache-lcy19247-LCY
+      - cache-control-slwdc9035-CONTROL-SLWDC, cache-lcy19279-LCY
       X-Timer:
-      - S1573465628.949339,VS0,VE275
+      - S1573575020.114176,VS0,VE526
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/wafs/delete.yaml
+++ b/fastly/fixtures/wafs/delete.yaml
@@ -3,7 +3,7 @@ version: 1
 interactions:
 - request:
     body: |
-      {"data":{"type":"waf_firewall","id":"0MjXWp60xLZ3zwM6LlNoeU","attributes":{"service_version_number":"2"}}}
+      {"data":{"type":"waf_firewall","id":"59onHkuKX28AMcf0gOojis","attributes":{"service_version_number":"2"}}}
     form: {}
     headers:
       Accept:
@@ -11,8 +11,8 @@ interactions:
       Content-Type:
       - application/vnd.api+json
       User-Agent:
-      - FastlyGo/1.3.0 (+github.com/fastly/go-fastly; go1.13.3)
-    url: https://api.fastly.com/waf/firewalls/0MjXWp60xLZ3zwM6LlNoeU
+      - FastlyGo/1.3.0 (+github.com/fastly/go-fastly; go1.13.4)
+    url: https://api.fastly.com/waf/firewalls/59onHkuKX28AMcf0gOojis
     method: DELETE
   response:
     body: ""
@@ -20,7 +20,7 @@ interactions:
       Accept-Ranges:
       - bytes
       Date:
-      - Mon, 11 Nov 2019 09:47:13 GMT
+      - Tue, 12 Nov 2019 16:10:24 GMT
       Status:
       - 204 No Content
       Strict-Transport-Security:
@@ -34,9 +34,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Served-By:
-      - cache-control-slwdc9036-CONTROL-SLWDC, cache-lcy19247-LCY
+      - cache-control-slwdc9037-CONTROL-SLWDC, cache-lcy19279-LCY
       X-Timer:
-      - S1573465633.163824,VS0,VE370
+      - S1573575025.533117,VS0,VE317
     status: 204 No Content
     code: 204
     duration: ""

--- a/fastly/fixtures/wafs/delete.yaml
+++ b/fastly/fixtures/wafs/delete.yaml
@@ -1,16 +1,18 @@
 ---
 version: 1
-rwmutex: {}
 interactions:
 - request:
-    body: ""
+    body: |
+      {"data":{"type":"waf_firewall","id":"0MjXWp60xLZ3zwM6LlNoeU","attributes":{"service_version_number":"2"}}}
     form: {}
     headers:
-      Fastly-Key:
-      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+      Accept:
+      - application/vnd.api+json
+      Content-Type:
+      - application/vnd.api+json
       User-Agent:
-      - FastlyGo/0.4.3.dev (+github.com/fastly/go-fastly; go1.12)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/54/wafs/2WK9ofHfHcPi3s6S2X0Z8m
+      - FastlyGo/1.3.0 (+github.com/fastly/go-fastly; go1.13.3)
+    url: https://api.fastly.com/waf/firewalls/0MjXWp60xLZ3zwM6LlNoeU
     method: DELETE
   response:
     body: ""
@@ -18,13 +20,12 @@ interactions:
       Accept-Ranges:
       - bytes
       Date:
-      - Sat, 11 May 2019 21:45:02 GMT
+      - Mon, 11 Nov 2019 09:47:13 GMT
       Status:
       - 204 No Content
       Strict-Transport-Security:
       - max-age=31536000
       Via:
-      - 1.1 varnish
       - 1.1 varnish
       X-Cache:
       - MISS, MISS
@@ -33,8 +34,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Served-By:
-      - cache-control-slwdc9035-CONTROL-SLWDC, cache-lax8631-LAX
+      - cache-control-slwdc9036-CONTROL-SLWDC, cache-lcy19247-LCY
       X-Timer:
-      - S1557611103.608075,VS0,VE254
+      - S1573465633.163824,VS0,VE370
     status: 204 No Content
     code: 204
+    duration: ""

--- a/fastly/fixtures/wafs/delete_service.yaml
+++ b/fastly/fixtures/wafs/delete_service.yaml
@@ -7,7 +7,7 @@ interactions:
     headers:
       User-Agent:
       - FastlyGo/1.3.0 (+github.com/fastly/go-fastly; go1.13.3)
-    url: https://api.fastly.com/service/3hn15tWwwLhD47TJAYqj3C/version/2/response_object/WAf_Response
+    url: https://api.fastly.com/service/3hn15tWwwLhD47TJAYqj3C
     method: DELETE
   response:
     body: '{"status":"ok"}'
@@ -19,9 +19,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 11 Nov 2019 09:47:14 GMT
+      - Mon, 11 Nov 2019 09:47:15 GMT
       Fastly-Ratelimit-Remaining:
-      - "992"
+      - "989"
       Fastly-Ratelimit-Reset:
       - "1573466400"
       Status:
@@ -37,9 +37,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9036-CONTROL-SLWDC, cache-lcy19247-LCY
+      - cache-control-slwdc9037-CONTROL-SLWDC, cache-lcy19247-LCY
       X-Timer:
-      - S1573465634.220060,VS0,VE339
+      - S1573465635.369825,VS0,VE185
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/wafs/delete_service.yaml
+++ b/fastly/fixtures/wafs/delete_service.yaml
@@ -6,8 +6,8 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/1.3.0 (+github.com/fastly/go-fastly; go1.13.3)
-    url: https://api.fastly.com/service/3hn15tWwwLhD47TJAYqj3C
+      - FastlyGo/1.3.0 (+github.com/fastly/go-fastly; go1.13.4)
+    url: https://api.fastly.com/service/6gkEdARZ3mPzhQvdi2YH3j
     method: DELETE
   response:
     body: '{"status":"ok"}'
@@ -19,11 +19,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 11 Nov 2019 09:47:15 GMT
+      - Tue, 12 Nov 2019 16:10:27 GMT
       Fastly-Ratelimit-Remaining:
-      - "989"
+      - "967"
       Fastly-Ratelimit-Reset:
-      - "1573466400"
+      - "1573578000"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -37,9 +37,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9037-CONTROL-SLWDC, cache-lcy19247-LCY
+      - cache-control-slwdc9036-CONTROL-SLWDC, cache-lcy19279-LCY
       X-Timer:
-      - S1573465635.369825,VS0,VE185
+      - S1573575027.804178,VS0,VE215
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/wafs/get.yaml
+++ b/fastly/fixtures/wafs/get.yaml
@@ -6,11 +6,11 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/1.3.0 (+github.com/fastly/go-fastly; go1.13.3)
-    url: https://api.fastly.com/waf/firewalls/0MjXWp60xLZ3zwM6LlNoeU?filter%5Bservice_version_number%5D=2
+      - FastlyGo/1.3.0 (+github.com/fastly/go-fastly; go1.13.4)
+    url: https://api.fastly.com/waf/firewalls/59onHkuKX28AMcf0gOojis?filter%5Bservice_version_number%5D=2
     method: GET
   response:
-    body: '{"data":{"id":"0MjXWp60xLZ3zwM6LlNoeU","type":"waf_firewall","attributes":{"service_id":"3hn15tWwwLhD47TJAYqj3C","prefetch_condition":"WAF_Prefetch","response":"WAf_Response","disabled":false,"service_version_number":2,"created_at":"2019-11-11T09:47:10Z","updated_at":"2019-11-11T09:47:10Z","active_rules_trustwave_log_count":0,"active_rules_trustwave_block_count":0,"active_rules_fastly_log_count":0,"active_rules_fastly_block_count":0,"active_rules_owasp_log_count":0,"active_rules_owasp_block_count":0,"active_rules_owasp_score_count":0}}}'
+    body: '{"data":{"id":"59onHkuKX28AMcf0gOojis","type":"waf_firewall","attributes":{"service_id":"6gkEdARZ3mPzhQvdi2YH3j","prefetch_condition":"WAF_Prefetch","response":"WAf_Response","disabled":false,"service_version_number":2,"created_at":"2019-11-12T16:10:23Z","updated_at":"2019-11-12T16:10:23Z","active_rules_trustwave_log_count":0,"active_rules_trustwave_block_count":0,"active_rules_fastly_log_count":0,"active_rules_fastly_block_count":0,"active_rules_owasp_log_count":0,"active_rules_owasp_block_count":0,"active_rules_owasp_score_count":0}}}'
     headers:
       Accept-Ranges:
       - bytes
@@ -21,7 +21,7 @@ interactions:
       Content-Type:
       - application/vnd.api+json
       Date:
-      - Mon, 11 Nov 2019 09:47:11 GMT
+      - Tue, 12 Nov 2019 16:10:23 GMT
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -35,9 +35,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Served-By:
-      - cache-control-slwdc9037-CONTROL-SLWDC, cache-lcy19247-LCY
+      - cache-control-slwdc9036-CONTROL-SLWDC, cache-lcy19279-LCY
       X-Timer:
-      - S1573465632.625088,VS0,VE217
+      - S1573575024.630073,VS0,VE173
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/wafs/get.yaml
+++ b/fastly/fixtures/wafs/get.yaml
@@ -1,36 +1,32 @@
 ---
 version: 1
-rwmutex: {}
 interactions:
 - request:
     body: ""
     form: {}
     headers:
-      Fastly-Key:
-      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
-      - FastlyGo/0.4.3.dev (+github.com/fastly/go-fastly; go1.12)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/54/wafs/2WK9ofHfHcPi3s6S2X0Z8m
+      - FastlyGo/1.3.0 (+github.com/fastly/go-fastly; go1.13.3)
+    url: https://api.fastly.com/waf/firewalls/0MjXWp60xLZ3zwM6LlNoeU?filter%5Bservice_version_number%5D=2
     method: GET
   response:
-    body: '{"data":{"id":"2WK9ofHfHcPi3s6S2X0Z8m","type":"waf","attributes":{"last_push":null,"prefetch_condition":"test-waf-condition","response":"test-response-object","version":54,"service_id":"7i6HN3TK9wS159v2gPAZ8A","disabled":false,"rule_statuses_log_count":0,"rule_statuses_block_count":0,"rule_statuses_disabled_count":0},"relationships":{"configuration_set":{"data":{"id":"3vnl3cwPda9Q3WYCDRuGW","type":"configuration_set"}}}}}'
+    body: '{"data":{"id":"0MjXWp60xLZ3zwM6LlNoeU","type":"waf_firewall","attributes":{"service_id":"3hn15tWwwLhD47TJAYqj3C","prefetch_condition":"WAF_Prefetch","response":"WAf_Response","disabled":false,"service_version_number":2,"created_at":"2019-11-11T09:47:10Z","updated_at":"2019-11-11T09:47:10Z","active_rules_trustwave_log_count":0,"active_rules_trustwave_block_count":0,"active_rules_fastly_log_count":0,"active_rules_fastly_block_count":0,"active_rules_owasp_log_count":0,"active_rules_owasp_block_count":0,"active_rules_owasp_score_count":0}}}'
     headers:
       Accept-Ranges:
       - bytes
       Age:
       - "0"
       Content-Length:
-      - "425"
+      - "542"
       Content-Type:
       - application/vnd.api+json
       Date:
-      - Sat, 11 May 2019 21:45:01 GMT
+      - Mon, 11 Nov 2019 09:47:11 GMT
       Status:
       - 200 OK
       Strict-Transport-Security:
       - max-age=31536000
       Via:
-      - 1.1 varnish
       - 1.1 varnish
       X-Cache:
       - MISS, MISS
@@ -39,8 +35,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Served-By:
-      - cache-control-slwdc9037-CONTROL-SLWDC, cache-lax8631-LAX
+      - cache-control-slwdc9037-CONTROL-SLWDC, cache-lcy19247-LCY
       X-Timer:
-      - S1557611101.328100,VS0,VE372
+      - S1573465632.625088,VS0,VE217
     status: 200 OK
     code: 200
+    duration: ""

--- a/fastly/fixtures/wafs/list.yaml
+++ b/fastly/fixtures/wafs/list.yaml
@@ -6,22 +6,22 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/1.3.0 (+github.com/fastly/go-fastly; go1.13.3)
-    url: https://api.fastly.com/waf/firewalls?filter%5Bservice_id%5D=3hn15tWwwLhD47TJAYqj3C
+      - FastlyGo/1.3.0 (+github.com/fastly/go-fastly; go1.13.4)
+    url: https://api.fastly.com/waf/firewalls?filter%5Bservice_id%5D=6gkEdARZ3mPzhQvdi2YH3j&filter%5Bservice_version_number%5D=2
     method: GET
   response:
-    body: '{"data":[],"links":{"last":"https://api.fastly.com/waf/firewalls?filter[service_id]=3hn15tWwwLhD47TJAYqj3C\u0026page[number]=1\u0026page[size]=100","first":"https://api.fastly.com/waf/firewalls?filter[service_id]=3hn15tWwwLhD47TJAYqj3C\u0026page[number]=1\u0026page[size]=100"},"meta":{"current_page":1,"per_page":100,"record_count":0,"total_pages":1}}'
+    body: '{"data":[{"id":"59onHkuKX28AMcf0gOojis","type":"waf_firewall","attributes":{"service_id":"6gkEdARZ3mPzhQvdi2YH3j","prefetch_condition":"WAF_Prefetch","response":"WAf_Response","disabled":false,"service_version_number":2,"created_at":"2019-11-12T16:10:23Z","updated_at":"2019-11-12T16:10:23Z","active_rules_trustwave_log_count":0,"active_rules_trustwave_block_count":0,"active_rules_fastly_log_count":0,"active_rules_fastly_block_count":0,"active_rules_owasp_log_count":0,"active_rules_owasp_block_count":0,"active_rules_owasp_score_count":0}}],"links":{"last":"https://api.fastly.com/waf/firewalls?filter[service_id]=6gkEdARZ3mPzhQvdi2YH3j\u0026filter[service_version_number]=2\u0026page[number]=1\u0026page[size]=100","first":"https://api.fastly.com/waf/firewalls?filter[service_id]=6gkEdARZ3mPzhQvdi2YH3j\u0026filter[service_version_number]=2\u0026page[number]=1\u0026page[size]=100"},"meta":{"current_page":1,"per_page":100,"record_count":1,"total_pages":1}}'
     headers:
       Accept-Ranges:
       - bytes
       Age:
       - "0"
       Content-Length:
-      - "352"
+      - "961"
       Content-Type:
       - application/vnd.api+json
       Date:
-      - Mon, 11 Nov 2019 09:47:11 GMT
+      - Tue, 12 Nov 2019 16:10:23 GMT
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -35,9 +35,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Served-By:
-      - cache-control-slwdc9035-CONTROL-SLWDC, cache-lcy19247-LCY
+      - cache-control-slwdc9036-CONTROL-SLWDC, cache-lcy19279-LCY
       X-Timer:
-      - S1573465631.907164,VS0,VE653
+      - S1573575023.349598,VS0,VE175
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/wafs/list.yaml
+++ b/fastly/fixtures/wafs/list.yaml
@@ -1,36 +1,32 @@
 ---
 version: 1
-rwmutex: {}
 interactions:
 - request:
     body: ""
     form: {}
     headers:
-      Fastly-Key:
-      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
-      - FastlyGo/0.4.3.dev (+github.com/fastly/go-fastly; go1.12)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/54/wafs
+      - FastlyGo/1.3.0 (+github.com/fastly/go-fastly; go1.13.3)
+    url: https://api.fastly.com/waf/firewalls?filter%5Bservice_id%5D=3hn15tWwwLhD47TJAYqj3C
     method: GET
   response:
-    body: '{"data":[{"id":"2WK9ofHfHcPi3s6S2X0Z8m","type":"waf","attributes":{"last_push":null,"prefetch_condition":"test-waf-condition","response":"test-response-object","version":54,"service_id":"7i6HN3TK9wS159v2gPAZ8A","disabled":false,"rule_statuses_log_count":0,"rule_statuses_block_count":0,"rule_statuses_disabled_count":0}}],"links":{"last":"https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/54/wafs?page[number]=1\u0026page[size]=100","first":"https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/54/wafs?page[number]=1\u0026page[size]=100"},"meta":{"current_page":1,"per_page":100,"record_count":1,"total_pages":1}}'
+    body: '{"data":[],"links":{"last":"https://api.fastly.com/waf/firewalls?filter[service_id]=3hn15tWwwLhD47TJAYqj3C\u0026page[number]=1\u0026page[size]=100","first":"https://api.fastly.com/waf/firewalls?filter[service_id]=3hn15tWwwLhD47TJAYqj3C\u0026page[number]=1\u0026page[size]=100"},"meta":{"current_page":1,"per_page":100,"record_count":0,"total_pages":1}}'
     headers:
       Accept-Ranges:
       - bytes
       Age:
       - "0"
       Content-Length:
-      - "635"
+      - "352"
       Content-Type:
       - application/vnd.api+json
       Date:
-      - Sat, 11 May 2019 21:45:01 GMT
+      - Mon, 11 Nov 2019 09:47:11 GMT
       Status:
       - 200 OK
       Strict-Transport-Security:
       - max-age=31536000
       Via:
-      - 1.1 varnish
       - 1.1 varnish
       X-Cache:
       - MISS, MISS
@@ -39,8 +35,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Served-By:
-      - cache-control-slwdc9036-CONTROL-SLWDC, cache-lax8631-LAX
+      - cache-control-slwdc9035-CONTROL-SLWDC, cache-lcy19247-LCY
       X-Timer:
-      - S1557611101.825257,VS0,VE468
+      - S1573465631.907164,VS0,VE653
     status: 200 OK
     code: 200
+    duration: ""

--- a/fastly/fixtures/wafs/logging/cleanup.yaml
+++ b/fastly/fixtures/wafs/logging/cleanup.yaml
@@ -6,8 +6,8 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/1.3.0 (+github.com/fastly/go-fastly; go1.13.3)
-    url: https://api.fastly.com/service/3hn15tWwwLhD47TJAYqj3C/version/2/logging/syslog/test-syslog
+      - FastlyGo/1.3.0 (+github.com/fastly/go-fastly; go1.13.4)
+    url: https://api.fastly.com/service/6gkEdARZ3mPzhQvdi2YH3j/version/2/logging/syslog/test-syslog
     method: DELETE
   response:
     body: '{"status":"ok"}'
@@ -19,11 +19,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 11 Nov 2019 09:47:15 GMT
+      - Tue, 12 Nov 2019 16:10:26 GMT
       Fastly-Ratelimit-Remaining:
-      - "990"
+      - "968"
       Fastly-Ratelimit-Reset:
-      - "1573466400"
+      - "1573578000"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -37,9 +37,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9035-CONTROL-SLWDC, cache-lcy19247-LCY
+      - cache-control-slwdc9037-CONTROL-SLWDC, cache-lcy19279-LCY
       X-Timer:
-      - S1573465635.899987,VS0,VE466
+      - S1573575026.284242,VS0,VE480
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/wafs/logging/cleanup.yaml
+++ b/fastly/fixtures/wafs/logging/cleanup.yaml
@@ -1,16 +1,13 @@
 ---
 version: 1
-rwmutex: {}
 interactions:
 - request:
     body: ""
     form: {}
     headers:
-      Fastly-Key:
-      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
-      - FastlyGo/0.4.3.dev (+github.com/fastly/go-fastly; go1.12)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/54/logging/syslog/test-syslog
+      - FastlyGo/1.3.0 (+github.com/fastly/go-fastly; go1.13.3)
+    url: https://api.fastly.com/service/3hn15tWwwLhD47TJAYqj3C/version/2/logging/syslog/test-syslog
     method: DELETE
   response:
     body: '{"status":"ok"}'
@@ -22,11 +19,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sat, 11 May 2019 21:45:04 GMT
+      - Mon, 11 Nov 2019 09:47:15 GMT
       Fastly-Ratelimit-Remaining:
-      - "984"
+      - "990"
       Fastly-Ratelimit-Reset:
-      - "1557612000"
+      - "1573466400"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -35,14 +32,14 @@ interactions:
       - Accept-Encoding
       Via:
       - 1.1 varnish
-      - 1.1 varnish
       X-Cache:
       - MISS, MISS
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9037-CONTROL-SLWDC, cache-lax8631-LAX
+      - cache-control-slwdc9035-CONTROL-SLWDC, cache-lcy19247-LCY
       X-Timer:
-      - S1557611104.386426,VS0,VE311
+      - S1573465635.899987,VS0,VE466
     status: 200 OK
     code: 200
+    duration: ""

--- a/fastly/fixtures/wafs/logging/create.yaml
+++ b/fastly/fixtures/wafs/logging/create.yaml
@@ -2,10 +2,10 @@
 version: 1
 interactions:
 - request:
-    body: Service=3hn15tWwwLhD47TJAYqj3C&Version=2&address=example.com&format=format&format_version=2&hostname=example.com&message_type=classic&name=test-syslog&port=1234&token=abcd1234
+    body: Service=6gkEdARZ3mPzhQvdi2YH3j&Version=2&address=example.com&format=format&format_version=2&hostname=example.com&message_type=classic&name=test-syslog&port=1234&token=abcd1234
     form:
       Service:
-      - 3hn15tWwwLhD47TJAYqj3C
+      - 6gkEdARZ3mPzhQvdi2YH3j
       Version:
       - "2"
       address:
@@ -28,11 +28,11 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - FastlyGo/1.3.0 (+github.com/fastly/go-fastly; go1.13.3)
-    url: https://api.fastly.com/service/3hn15tWwwLhD47TJAYqj3C/version/2/logging/syslog
+      - FastlyGo/1.3.0 (+github.com/fastly/go-fastly; go1.13.4)
+    url: https://api.fastly.com/service/6gkEdARZ3mPzhQvdi2YH3j/version/2/logging/syslog
     method: POST
   response:
-    body: '{"address":"example.com","format":"format","format_version":"2","hostname":"example.com","message_type":"classic","name":"test-syslog","port":"1234","token":"abcd1234","service_id":"3hn15tWwwLhD47TJAYqj3C","version":"2","public_key":null,"response_condition":"","deleted_at":null,"updated_at":"2019-11-11T09:47:08Z","placement":null,"tls_client_key":null,"ipv4":null,"tls_ca_cert":null,"created_at":"2019-11-11T09:47:08Z","use_tls":"0","tls_hostname":null,"tls_client_cert":null}'
+    body: '{"address":"example.com","format":"format","format_version":"2","hostname":"example.com","message_type":"classic","name":"test-syslog","port":"1234","token":"abcd1234","service_id":"6gkEdARZ3mPzhQvdi2YH3j","version":"2","tls_hostname":null,"public_key":null,"use_tls":"0","deleted_at":null,"response_condition":"","tls_ca_cert":null,"placement":null,"updated_at":"2019-11-12T16:10:21Z","ipv4":null,"created_at":"2019-11-12T16:10:21Z","tls_client_cert":null,"tls_client_key":null}'
     headers:
       Accept-Ranges:
       - bytes
@@ -41,11 +41,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 11 Nov 2019 09:47:09 GMT
+      - Tue, 12 Nov 2019 16:10:21 GMT
       Fastly-Ratelimit-Remaining:
-      - "997"
+      - "975"
       Fastly-Ratelimit-Reset:
-      - "1573466400"
+      - "1573578000"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -59,9 +59,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9035-CONTROL-SLWDC, cache-lcy19247-LCY
+      - cache-control-slwdc9036-CONTROL-SLWDC, cache-lcy19279-LCY
       X-Timer:
-      - S1573465629.657095,VS0,VE600
+      - S1573575021.168593,VS0,VE780
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/wafs/logging/create.yaml
+++ b/fastly/fixtures/wafs/logging/create.yaml
@@ -1,14 +1,13 @@
 ---
 version: 1
-rwmutex: {}
 interactions:
 - request:
-    body: Service=7i6HN3TK9wS159v2gPAZ8A&Version=54&address=example.com&format=format&format_version=2&hostname=example.com&message_type=classic&name=test-syslog&port=1234&token=abcd1234
+    body: Service=3hn15tWwwLhD47TJAYqj3C&Version=2&address=example.com&format=format&format_version=2&hostname=example.com&message_type=classic&name=test-syslog&port=1234&token=abcd1234
     form:
       Service:
-      - 7i6HN3TK9wS159v2gPAZ8A
+      - 3hn15tWwwLhD47TJAYqj3C
       Version:
-      - "54"
+      - "2"
       address:
       - example.com
       format:
@@ -28,14 +27,12 @@ interactions:
     headers:
       Content-Type:
       - application/x-www-form-urlencoded
-      Fastly-Key:
-      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
-      - FastlyGo/0.4.3.dev (+github.com/fastly/go-fastly; go1.12)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/54/logging/syslog
+      - FastlyGo/1.3.0 (+github.com/fastly/go-fastly; go1.13.3)
+    url: https://api.fastly.com/service/3hn15tWwwLhD47TJAYqj3C/version/2/logging/syslog
     method: POST
   response:
-    body: '{"address":"example.com","format":"format","format_version":"2","hostname":"example.com","message_type":"classic","name":"test-syslog","port":"1234","token":"abcd1234","service_id":"7i6HN3TK9wS159v2gPAZ8A","version":"54","tls_hostname":null,"use_tls":"0","created_at":"2019-05-11T21:44:58Z","response_condition":"","updated_at":"2019-05-11T21:44:59Z","tls_ca_cert":null,"placement":null,"deleted_at":null,"ipv4":null,"public_key":null}'
+    body: '{"address":"example.com","format":"format","format_version":"2","hostname":"example.com","message_type":"classic","name":"test-syslog","port":"1234","token":"abcd1234","service_id":"3hn15tWwwLhD47TJAYqj3C","version":"2","public_key":null,"response_condition":"","deleted_at":null,"updated_at":"2019-11-11T09:47:08Z","placement":null,"tls_client_key":null,"ipv4":null,"tls_ca_cert":null,"created_at":"2019-11-11T09:47:08Z","use_tls":"0","tls_hostname":null,"tls_client_cert":null}'
     headers:
       Accept-Ranges:
       - bytes
@@ -44,11 +41,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sat, 11 May 2019 21:44:59 GMT
+      - Mon, 11 Nov 2019 09:47:09 GMT
       Fastly-Ratelimit-Remaining:
-      - "991"
+      - "997"
       Fastly-Ratelimit-Reset:
-      - "1557612000"
+      - "1573466400"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -57,14 +54,14 @@ interactions:
       - Accept-Encoding
       Via:
       - 1.1 varnish
-      - 1.1 varnish
       X-Cache:
       - MISS, MISS
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9035-CONTROL-SLWDC, cache-lax8631-LAX
+      - cache-control-slwdc9035-CONTROL-SLWDC, cache-lcy19247-LCY
       X-Timer:
-      - S1557611099.652892,VS0,VE682
+      - S1573465629.657095,VS0,VE600
     status: 200 OK
     code: 200
+    duration: ""

--- a/fastly/fixtures/wafs/response_object/cleanup.yaml
+++ b/fastly/fixtures/wafs/response_object/cleanup.yaml
@@ -6,8 +6,8 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/1.3.0 (+github.com/fastly/go-fastly; go1.13.3)
-    url: https://api.fastly.com/service/3hn15tWwwLhD47TJAYqj3C/version/2/response_object/WAf_Response
+      - FastlyGo/1.3.0 (+github.com/fastly/go-fastly; go1.13.4)
+    url: https://api.fastly.com/service/6gkEdARZ3mPzhQvdi2YH3j/version/2/response_object/WAf_Response
     method: DELETE
   response:
     body: '{"status":"ok"}'
@@ -19,11 +19,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 11 Nov 2019 09:47:14 GMT
+      - Tue, 12 Nov 2019 16:10:25 GMT
       Fastly-Ratelimit-Remaining:
-      - "992"
+      - "970"
       Fastly-Ratelimit-Reset:
-      - "1573466400"
+      - "1573578000"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -37,9 +37,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9036-CONTROL-SLWDC, cache-lcy19247-LCY
+      - cache-control-slwdc9036-CONTROL-SLWDC, cache-lcy19279-LCY
       X-Timer:
-      - S1573465634.220060,VS0,VE339
+      - S1573575026.606832,VS0,VE339
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/wafs/response_object/cleanup_another.yaml
+++ b/fastly/fixtures/wafs/response_object/cleanup_another.yaml
@@ -1,16 +1,13 @@
 ---
 version: 1
-rwmutex: {}
 interactions:
 - request:
     body: ""
     form: {}
     headers:
-      Fastly-Key:
-      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
-      - FastlyGo/0.4.3.dev (+github.com/fastly/go-fastly; go1.12)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/54/response_object/test-response-object-2
+      - FastlyGo/1.3.0 (+github.com/fastly/go-fastly; go1.13.3)
+    url: https://api.fastly.com/service/3hn15tWwwLhD47TJAYqj3C/version/2/response_object/test-response-object-2
     method: DELETE
   response:
     body: '{"status":"ok"}'
@@ -22,11 +19,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sat, 11 May 2019 21:45:03 GMT
+      - Mon, 11 Nov 2019 09:47:13 GMT
       Fastly-Ratelimit-Remaining:
-      - "987"
+      - "993"
       Fastly-Ratelimit-Reset:
-      - "1557612000"
+      - "1573466400"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -35,14 +32,14 @@ interactions:
       - Accept-Encoding
       Via:
       - 1.1 varnish
-      - 1.1 varnish
       X-Cache:
       - MISS, MISS
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9036-CONTROL-SLWDC, cache-lax8631-LAX
+      - cache-control-slwdc9035-CONTROL-SLWDC, cache-lcy19247-LCY
       X-Timer:
-      - S1557611103.897977,VS0,VE289
+      - S1573465634.570579,VS0,VE416
     status: 200 OK
     code: 200
+    duration: ""

--- a/fastly/fixtures/wafs/response_object/cleanup_another.yaml
+++ b/fastly/fixtures/wafs/response_object/cleanup_another.yaml
@@ -6,8 +6,8 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/1.3.0 (+github.com/fastly/go-fastly; go1.13.3)
-    url: https://api.fastly.com/service/3hn15tWwwLhD47TJAYqj3C/version/2/response_object/test-response-object-2
+      - FastlyGo/1.3.0 (+github.com/fastly/go-fastly; go1.13.4)
+    url: https://api.fastly.com/service/6gkEdARZ3mPzhQvdi2YH3j/version/2/response_object/test-response-object-2
     method: DELETE
   response:
     body: '{"status":"ok"}'
@@ -19,11 +19,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 11 Nov 2019 09:47:13 GMT
+      - Tue, 12 Nov 2019 16:10:25 GMT
       Fastly-Ratelimit-Remaining:
-      - "993"
+      - "971"
       Fastly-Ratelimit-Reset:
-      - "1573466400"
+      - "1573578000"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -37,9 +37,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9035-CONTROL-SLWDC, cache-lcy19247-LCY
+      - cache-control-slwdc9035-CONTROL-SLWDC, cache-lcy19279-LCY
       X-Timer:
-      - S1573465634.570579,VS0,VE416
+      - S1573575025.955392,VS0,VE478
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/wafs/response_object/create.yaml
+++ b/fastly/fixtures/wafs/response_object/create.yaml
@@ -2,10 +2,10 @@
 version: 1
 interactions:
 - request:
-    body: Service=3hn15tWwwLhD47TJAYqj3C&Version=2&content=abcd&content_type=text%2Fplain&name=WAf_Response&response=Ok&status=200
+    body: Service=6gkEdARZ3mPzhQvdi2YH3j&Version=2&content=abcd&content_type=text%2Fplain&name=WAf_Response&response=Ok&status=200
     form:
       Service:
-      - 3hn15tWwwLhD47TJAYqj3C
+      - 6gkEdARZ3mPzhQvdi2YH3j
       Version:
       - "2"
       content:
@@ -22,11 +22,11 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - FastlyGo/1.3.0 (+github.com/fastly/go-fastly; go1.13.3)
-    url: https://api.fastly.com/service/3hn15tWwwLhD47TJAYqj3C/version/2/response_object
+      - FastlyGo/1.3.0 (+github.com/fastly/go-fastly; go1.13.4)
+    url: https://api.fastly.com/service/6gkEdARZ3mPzhQvdi2YH3j/version/2/response_object
     method: POST
   response:
-    body: '{"content":"abcd","content_type":"text/plain","name":"WAf_Response","response":"Ok","status":"200","service_id":"3hn15tWwwLhD47TJAYqj3C","version":"2","deleted_at":null,"request_condition":"","cache_condition":"","created_at":"2019-11-11T09:47:09Z","updated_at":"2019-11-11T09:47:09Z"}'
+    body: '{"content":"abcd","content_type":"text/plain","name":"WAf_Response","response":"Ok","status":"200","service_id":"6gkEdARZ3mPzhQvdi2YH3j","version":"2","created_at":"2019-11-12T16:10:22Z","deleted_at":null,"updated_at":"2019-11-12T16:10:22Z","cache_condition":"","request_condition":""}'
     headers:
       Accept-Ranges:
       - bytes
@@ -35,11 +35,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 11 Nov 2019 09:47:09 GMT
+      - Tue, 12 Nov 2019 16:10:22 GMT
       Fastly-Ratelimit-Remaining:
-      - "995"
+      - "973"
       Fastly-Ratelimit-Reset:
-      - "1573466400"
+      - "1573578000"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -53,9 +53,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9035-CONTROL-SLWDC, cache-lcy19247-LCY
+      - cache-control-slwdc9037-CONTROL-SLWDC, cache-lcy19279-LCY
       X-Timer:
-      - S1573465630.578042,VS0,VE303
+      - S1573575022.149894,VS0,VE343
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/wafs/response_object/create.yaml
+++ b/fastly/fixtures/wafs/response_object/create.yaml
@@ -1,20 +1,19 @@
 ---
 version: 1
-rwmutex: {}
 interactions:
 - request:
-    body: Service=7i6HN3TK9wS159v2gPAZ8A&Version=54&content=abcd&content_type=text%2Fplain&name=test-response-object&response=Ok&status=200
+    body: Service=3hn15tWwwLhD47TJAYqj3C&Version=2&content=abcd&content_type=text%2Fplain&name=WAf_Response&response=Ok&status=200
     form:
       Service:
-      - 7i6HN3TK9wS159v2gPAZ8A
+      - 3hn15tWwwLhD47TJAYqj3C
       Version:
-      - "54"
+      - "2"
       content:
       - abcd
       content_type:
       - text/plain
       name:
-      - test-response-object
+      - WAf_Response
       response:
       - Ok
       status:
@@ -22,14 +21,12 @@ interactions:
     headers:
       Content-Type:
       - application/x-www-form-urlencoded
-      Fastly-Key:
-      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
-      - FastlyGo/0.4.3.dev (+github.com/fastly/go-fastly; go1.12)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/54/response_object
+      - FastlyGo/1.3.0 (+github.com/fastly/go-fastly; go1.13.3)
+    url: https://api.fastly.com/service/3hn15tWwwLhD47TJAYqj3C/version/2/response_object
     method: POST
   response:
-    body: '{"content":"abcd","content_type":"text/plain","name":"test-response-object","response":"Ok","status":"200","service_id":"7i6HN3TK9wS159v2gPAZ8A","version":"54","deleted_at":null,"created_at":"2019-05-11T21:44:59Z","request_condition":"","updated_at":"2019-05-11T21:44:59Z","cache_condition":""}'
+    body: '{"content":"abcd","content_type":"text/plain","name":"WAf_Response","response":"Ok","status":"200","service_id":"3hn15tWwwLhD47TJAYqj3C","version":"2","deleted_at":null,"request_condition":"","cache_condition":"","created_at":"2019-11-11T09:47:09Z","updated_at":"2019-11-11T09:47:09Z"}'
     headers:
       Accept-Ranges:
       - bytes
@@ -38,11 +35,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sat, 11 May 2019 21:45:00 GMT
+      - Mon, 11 Nov 2019 09:47:09 GMT
       Fastly-Ratelimit-Remaining:
-      - "989"
+      - "995"
       Fastly-Ratelimit-Reset:
-      - "1557612000"
+      - "1573466400"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -51,14 +48,14 @@ interactions:
       - Accept-Encoding
       Via:
       - 1.1 varnish
-      - 1.1 varnish
       X-Cache:
       - MISS, MISS
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9035-CONTROL-SLWDC, cache-lax8631-LAX
+      - cache-control-slwdc9035-CONTROL-SLWDC, cache-lcy19247-LCY
       X-Timer:
-      - S1557611100.704714,VS0,VE321
+      - S1573465630.578042,VS0,VE303
     status: 200 OK
     code: 200
+    duration: ""

--- a/fastly/fixtures/wafs/response_object/create_another.yaml
+++ b/fastly/fixtures/wafs/response_object/create_another.yaml
@@ -2,10 +2,10 @@
 version: 1
 interactions:
 - request:
-    body: Service=3hn15tWwwLhD47TJAYqj3C&Version=2&content=efgh&content_type=text%2Fplain&name=test-response-object-2&response=Ok&status=200
+    body: Service=6gkEdARZ3mPzhQvdi2YH3j&Version=2&content=efgh&content_type=text%2Fplain&name=test-response-object-2&response=Ok&status=200
     form:
       Service:
-      - 3hn15tWwwLhD47TJAYqj3C
+      - 6gkEdARZ3mPzhQvdi2YH3j
       Version:
       - "2"
       content:
@@ -22,11 +22,11 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - FastlyGo/1.3.0 (+github.com/fastly/go-fastly; go1.13.3)
-    url: https://api.fastly.com/service/3hn15tWwwLhD47TJAYqj3C/version/2/response_object
+      - FastlyGo/1.3.0 (+github.com/fastly/go-fastly; go1.13.4)
+    url: https://api.fastly.com/service/6gkEdARZ3mPzhQvdi2YH3j/version/2/response_object
     method: POST
   response:
-    body: '{"content":"efgh","content_type":"text/plain","name":"test-response-object-2","response":"Ok","status":"200","service_id":"3hn15tWwwLhD47TJAYqj3C","version":"2","cache_condition":"","request_condition":"","deleted_at":null,"updated_at":"2019-11-11T09:47:12Z","created_at":"2019-11-11T09:47:12Z"}'
+    body: '{"content":"efgh","content_type":"text/plain","name":"test-response-object-2","response":"Ok","status":"200","service_id":"6gkEdARZ3mPzhQvdi2YH3j","version":"2","deleted_at":null,"updated_at":"2019-11-12T16:10:24Z","request_condition":"","created_at":"2019-11-12T16:10:24Z","cache_condition":""}'
     headers:
       Accept-Ranges:
       - bytes
@@ -35,11 +35,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 11 Nov 2019 09:47:12 GMT
+      - Tue, 12 Nov 2019 16:10:24 GMT
       Fastly-Ratelimit-Remaining:
-      - "994"
+      - "972"
       Fastly-Ratelimit-Reset:
-      - "1573466400"
+      - "1573578000"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -53,9 +53,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9036-CONTROL-SLWDC, cache-lcy19247-LCY
+      - cache-control-slwdc9037-CONTROL-SLWDC, cache-lcy19279-LCY
       X-Timer:
-      - S1573465632.945728,VS0,VE398
+      - S1573575024.828564,VS0,VE366
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/wafs/response_object/create_another.yaml
+++ b/fastly/fixtures/wafs/response_object/create_another.yaml
@@ -1,14 +1,13 @@
 ---
 version: 1
-rwmutex: {}
 interactions:
 - request:
-    body: Service=7i6HN3TK9wS159v2gPAZ8A&Version=54&content=efgh&content_type=text%2Fplain&name=test-response-object-2&response=Ok&status=200
+    body: Service=3hn15tWwwLhD47TJAYqj3C&Version=2&content=efgh&content_type=text%2Fplain&name=test-response-object-2&response=Ok&status=200
     form:
       Service:
-      - 7i6HN3TK9wS159v2gPAZ8A
+      - 3hn15tWwwLhD47TJAYqj3C
       Version:
-      - "54"
+      - "2"
       content:
       - efgh
       content_type:
@@ -22,14 +21,12 @@ interactions:
     headers:
       Content-Type:
       - application/x-www-form-urlencoded
-      Fastly-Key:
-      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
-      - FastlyGo/0.4.3.dev (+github.com/fastly/go-fastly; go1.12)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/54/response_object
+      - FastlyGo/1.3.0 (+github.com/fastly/go-fastly; go1.13.3)
+    url: https://api.fastly.com/service/3hn15tWwwLhD47TJAYqj3C/version/2/response_object
     method: POST
   response:
-    body: '{"content":"efgh","content_type":"text/plain","name":"test-response-object-2","response":"Ok","status":"200","service_id":"7i6HN3TK9wS159v2gPAZ8A","version":"54","cache_condition":"","created_at":"2019-05-11T21:45:01Z","request_condition":"","deleted_at":null,"updated_at":"2019-05-11T21:45:01Z"}'
+    body: '{"content":"efgh","content_type":"text/plain","name":"test-response-object-2","response":"Ok","status":"200","service_id":"3hn15tWwwLhD47TJAYqj3C","version":"2","cache_condition":"","request_condition":"","deleted_at":null,"updated_at":"2019-11-11T09:47:12Z","created_at":"2019-11-11T09:47:12Z"}'
     headers:
       Accept-Ranges:
       - bytes
@@ -38,11 +35,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sat, 11 May 2019 21:45:01 GMT
+      - Mon, 11 Nov 2019 09:47:12 GMT
       Fastly-Ratelimit-Remaining:
-      - "988"
+      - "994"
       Fastly-Ratelimit-Reset:
-      - "1557612000"
+      - "1573466400"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -51,14 +48,14 @@ interactions:
       - Accept-Encoding
       Via:
       - 1.1 varnish
-      - 1.1 varnish
       X-Cache:
       - MISS, MISS
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9037-CONTROL-SLWDC, cache-lax8631-LAX
+      - cache-control-slwdc9036-CONTROL-SLWDC, cache-lcy19247-LCY
       X-Timer:
-      - S1557611102.735005,VS0,VE257
+      - S1573465632.945728,VS0,VE398
     status: 200 OK
     code: 200
+    duration: ""

--- a/fastly/fixtures/wafs/update.yaml
+++ b/fastly/fixtures/wafs/update.yaml
@@ -1,26 +1,23 @@
 ---
 version: 1
-rwmutex: {}
 interactions:
 - request:
     body: |
-      {"data":{"type":"waf","id":"2WK9ofHfHcPi3s6S2X0Z8m","attributes":{"response":"test-response-object-2"}}}
+      {"data":{"type":"waf_firewall","id":"0MjXWp60xLZ3zwM6LlNoeU","attributes":{"prefetch_condition":"","response":"test-response-object-2","service_id":"3hn15tWwwLhD47TJAYqj3C","service_version_number":"2"}}}
     form: {}
     headers:
       Accept:
       - application/vnd.api+json
       Content-Type:
       - application/vnd.api+json
-      Fastly-Key:
-      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
-      - FastlyGo/0.4.3.dev (+github.com/fastly/go-fastly; go1.12)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/54/wafs/2WK9ofHfHcPi3s6S2X0Z8m
+      - FastlyGo/1.3.0 (+github.com/fastly/go-fastly; go1.13.3)
+    url: https://api.fastly.com/waf/firewalls/0MjXWp60xLZ3zwM6LlNoeU
     method: PATCH
   response:
-    body: '{"data":{"id":"2WK9ofHfHcPi3s6S2X0Z8m","type":"waf","attributes":{"last_push":null,"prefetch_condition":"test-waf-condition","response":"test-response-object-2","version":54,"service_id":"7i6HN3TK9wS159v2gPAZ8A","disabled":false,"rule_statuses_log_count":0,"rule_statuses_block_count":0,"rule_statuses_disabled_count":0},"relationships":{"configuration_set":{"data":{"id":"3vnl3cwPda9Q3WYCDRuGW","type":"configuration_set"}},"owasp":{"data":{"id":"4Jh5ZWRaYGgPdCdgQZNzyk","type":"owasp"}}}},"meta":{"warnings":[{"title":"This
+    body: '{"data":{"id":"0MjXWp60xLZ3zwM6LlNoeU","type":"waf_firewall","attributes":{"service_id":"3hn15tWwwLhD47TJAYqj3C","prefetch_condition":"","response":"test-response-object-2","disabled":false,"service_version_number":2,"created_at":"2019-11-11T09:47:10Z","updated_at":"2019-11-11T09:47:10Z","active_rules_trustwave_log_count":0,"active_rules_trustwave_block_count":0,"active_rules_fastly_log_count":0,"active_rules_fastly_block_count":0,"active_rules_owasp_log_count":0,"active_rules_owasp_block_count":0,"active_rules_owasp_score_count":0}},"meta":{"warnings":[{"title":"This
       version of this service must be active","detail":"You may only update the WAF
-      VCL on an active version of a service.  The version 54 of service 7i6HN3TK9wS159v2gPAZ8A
+      VCL on an active version of a service.  The version 2 of service 3hn15tWwwLhD47TJAYqj3C
       is not active.  You may activate it through https://app.fastly.com or through
       the API: https://docs.fastly.com/api/config#version  Be sure to review the version''s
       changes before activating it."}]}}'
@@ -28,17 +25,16 @@ interactions:
       Accept-Ranges:
       - bytes
       Content-Length:
-      - "890"
+      - "938"
       Content-Type:
       - application/vnd.api+json
       Date:
-      - Sat, 11 May 2019 21:45:02 GMT
+      - Mon, 11 Nov 2019 09:47:13 GMT
       Status:
       - 200 OK
       Strict-Transport-Security:
       - max-age=31536000
       Via:
-      - 1.1 varnish
       - 1.1 varnish
       X-Cache:
       - MISS, MISS
@@ -47,8 +43,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Served-By:
-      - cache-control-slwdc9036-CONTROL-SLWDC, cache-lax8631-LAX
+      - cache-control-slwdc9037-CONTROL-SLWDC, cache-lcy19247-LCY
       X-Timer:
-      - S1557611102.061591,VS0,VE521
+      - S1573465632.447543,VS0,VE598
     status: 200 OK
     code: 200
+    duration: ""

--- a/fastly/fixtures/wafs/update.yaml
+++ b/fastly/fixtures/wafs/update.yaml
@@ -3,7 +3,7 @@ version: 1
 interactions:
 - request:
     body: |
-      {"data":{"type":"waf_firewall","id":"0MjXWp60xLZ3zwM6LlNoeU","attributes":{"prefetch_condition":"","response":"test-response-object-2","service_id":"3hn15tWwwLhD47TJAYqj3C","service_version_number":"2"}}}
+      {"data":{"type":"waf_firewall","id":"59onHkuKX28AMcf0gOojis","attributes":{"prefetch_condition":"","response":"test-response-object-2","service_id":"6gkEdARZ3mPzhQvdi2YH3j","service_version_number":"2"}}}
     form: {}
     headers:
       Accept:
@@ -11,13 +11,13 @@ interactions:
       Content-Type:
       - application/vnd.api+json
       User-Agent:
-      - FastlyGo/1.3.0 (+github.com/fastly/go-fastly; go1.13.3)
-    url: https://api.fastly.com/waf/firewalls/0MjXWp60xLZ3zwM6LlNoeU
+      - FastlyGo/1.3.0 (+github.com/fastly/go-fastly; go1.13.4)
+    url: https://api.fastly.com/waf/firewalls/59onHkuKX28AMcf0gOojis
     method: PATCH
   response:
-    body: '{"data":{"id":"0MjXWp60xLZ3zwM6LlNoeU","type":"waf_firewall","attributes":{"service_id":"3hn15tWwwLhD47TJAYqj3C","prefetch_condition":"","response":"test-response-object-2","disabled":false,"service_version_number":2,"created_at":"2019-11-11T09:47:10Z","updated_at":"2019-11-11T09:47:10Z","active_rules_trustwave_log_count":0,"active_rules_trustwave_block_count":0,"active_rules_fastly_log_count":0,"active_rules_fastly_block_count":0,"active_rules_owasp_log_count":0,"active_rules_owasp_block_count":0,"active_rules_owasp_score_count":0}},"meta":{"warnings":[{"title":"This
+    body: '{"data":{"id":"59onHkuKX28AMcf0gOojis","type":"waf_firewall","attributes":{"service_id":"6gkEdARZ3mPzhQvdi2YH3j","prefetch_condition":"","response":"test-response-object-2","disabled":false,"service_version_number":2,"created_at":"2019-11-12T16:10:23Z","updated_at":"2019-11-12T16:10:23Z","active_rules_trustwave_log_count":0,"active_rules_trustwave_block_count":0,"active_rules_fastly_log_count":0,"active_rules_fastly_block_count":0,"active_rules_owasp_log_count":0,"active_rules_owasp_block_count":0,"active_rules_owasp_score_count":0}},"meta":{"warnings":[{"title":"This
       version of this service must be active","detail":"You may only update the WAF
-      VCL on an active version of a service.  The version 2 of service 3hn15tWwwLhD47TJAYqj3C
+      VCL on an active version of a service.  The version 2 of service 6gkEdARZ3mPzhQvdi2YH3j
       is not active.  You may activate it through https://app.fastly.com or through
       the API: https://docs.fastly.com/api/config#version  Be sure to review the version''s
       changes before activating it."}]}}'
@@ -29,7 +29,7 @@ interactions:
       Content-Type:
       - application/vnd.api+json
       Date:
-      - Mon, 11 Nov 2019 09:47:13 GMT
+      - Tue, 12 Nov 2019 16:10:24 GMT
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -43,9 +43,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Served-By:
-      - cache-control-slwdc9037-CONTROL-SLWDC, cache-lcy19247-LCY
+      - cache-control-slwdc9035-CONTROL-SLWDC, cache-lcy19279-LCY
       X-Timer:
-      - S1573465632.447543,VS0,VE598
+      - S1573575024.240097,VS0,VE283
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/wafs/version.yaml
+++ b/fastly/fixtures/wafs/version.yaml
@@ -2,19 +2,19 @@
 version: 1
 interactions:
 - request:
-    body: Service=3hn15tWwwLhD47TJAYqj3C
+    body: Service=6gkEdARZ3mPzhQvdi2YH3j
     form:
       Service:
-      - 3hn15tWwwLhD47TJAYqj3C
+      - 6gkEdARZ3mPzhQvdi2YH3j
     headers:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - FastlyGo/1.3.0 (+github.com/fastly/go-fastly; go1.13.3)
-    url: https://api.fastly.com/service/3hn15tWwwLhD47TJAYqj3C/version
+      - FastlyGo/1.3.0 (+github.com/fastly/go-fastly; go1.13.4)
+    url: https://api.fastly.com/service/6gkEdARZ3mPzhQvdi2YH3j/version
     method: POST
   response:
-    body: '{"service_id":"3hn15tWwwLhD47TJAYqj3C","number":2}'
+    body: '{"service_id":"6gkEdARZ3mPzhQvdi2YH3j","number":2}'
     headers:
       Accept-Ranges:
       - bytes
@@ -23,11 +23,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 11 Nov 2019 09:47:08 GMT
+      - Tue, 12 Nov 2019 16:10:21 GMT
       Fastly-Ratelimit-Remaining:
-      - "998"
+      - "976"
       Fastly-Ratelimit-Reset:
-      - "1573466400"
+      - "1573578000"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -41,9 +41,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9035-CONTROL-SLWDC, cache-lcy19247-LCY
+      - cache-control-slwdc9037-CONTROL-SLWDC, cache-lcy19279-LCY
       X-Timer:
-      - S1573465628.248996,VS0,VE391
+      - S1573575021.764746,VS0,VE374
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/waf.go
+++ b/fastly/waf.go
@@ -831,6 +831,7 @@ type linksResponse struct {
 	Links paginationInfo `json:"links"`
 }
 
+// infoResponse used to pull the links and meta from the result
 type infoResponse struct {
 	Links paginationInfo `json:"links"`
 	Meta  metaInfo       `json:"meta"`
@@ -849,6 +850,7 @@ type GetWAFRuleStatusesResponse struct {
 	Rules []*WAFRuleStatus
 }
 
+// metaInfo stores information about the result returned by the server
 type metaInfo struct {
 	CurrentPage int `json:"current_page,omitempty"`
 	PerPage     int `json:"per_page,omitempty"`

--- a/fastly/waf.go
+++ b/fastly/waf.go
@@ -123,7 +123,7 @@ func (c *Client) ListWAFs(i *ListWAFsInput) (*WAFResponse, error) {
 	}, nil
 }
 
-// CreateWAFInput is used as input to the CreateWAF and UpdateWAF function.
+// CreateWAFInput is used as input to the CreateWAF function.
 type CreateWAFInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
@@ -198,7 +198,7 @@ func (c *Client) GetWAF(i *GetWAFInput) (*WAF, error) {
 	return &waf, nil
 }
 
-// UpdateWAFInput is used as input to the CreateWAF and UpdateWAF function.
+// UpdateWAFInput is used as input to the UpdateWAF function.
 type UpdateWAFInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.

--- a/fastly/waf.go
+++ b/fastly/waf.go
@@ -65,7 +65,8 @@ func (c *Client) ListWAFs(i *ListWAFsInput) ([]*WAF, error) {
 	path := fmt.Sprint("/waf/firewalls")
 	resp, err := c.Get(path, &RequestOptions{
 		Params: map[string]string{
-			"filter[service_id]": i.Service,
+			"filter[service_id]":             i.Service,
+			"filter[service_version_number]": i.Version,
 		},
 	})
 	if err != nil {
@@ -328,7 +329,7 @@ func (c *Client) GetOWASP(i *GetOWASPInput) (*OWASP, error) {
 	if i.Service == "" {
 		return nil, ErrMissingService
 	}
-	
+
 	if i.ID == "" {
 		return nil, ErrMissingWAFID
 	}

--- a/fastly/waf.go
+++ b/fastly/waf.go
@@ -92,8 +92,7 @@ func (i *ListWAFsInput) formatFilters() map[string]string {
 // ListWAFs returns the list of wafs for the configuration version.
 func (c *Client) ListWAFs(i *ListWAFsInput) (*WAFResponse, error) {
 
-	path := fmt.Sprint("/waf/firewalls")
-	resp, err := c.Get(path, &RequestOptions{
+	resp, err := c.Get("/waf/firewalls", &RequestOptions{
 		Params: i.formatFilters(),
 	})
 	if err != nil {
@@ -885,7 +884,9 @@ func getInfo(body io.Reader) (infoResponse, io.Reader, error) {
 	}
 
 	var info infoResponse
-	json.Unmarshal(bodyBytes, &info)
+	if err := json.Unmarshal(bodyBytes, &info); err != nil {
+		return infoResponse{}, nil, err
+	}
 	return info, bytes.NewReader(buf.Bytes()), nil
 }
 

--- a/fastly/waf_test.go
+++ b/fastly/waf_test.go
@@ -261,13 +261,13 @@ func TestClient_GetWAF_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	// _, err = testClient.GetWAF(&GetWAFInput{
-	// 	Service: "foo",
-	// 	Version: "1",
-	// })
-	// if err != ErrMissingWAFID {
-	// 	t.Errorf("bad error: %s", err)
-	// }
+	_, err = testClient.GetWAF(&GetWAFInput{
+		Service: "foo",
+		Version: "1",
+	})
+	if err != ErrMissingWAFID {
+		t.Errorf("bad error: %s", err)
+	}
 }
 
 //

--- a/fastly/waf_test.go
+++ b/fastly/waf_test.go
@@ -102,7 +102,7 @@ func TestClient_WAFs(t *testing.T) {
 	// Create
 	var waf *WAF
 	record(t, fixtureBase+"/create", func(c *Client) {
-		waf, err = c.CreateWAF(&WAFInput{
+		waf, err = c.CreateWAF(&CreateWAFInput{
 			Service:           testService.ID,
 			Version:           strconv.Itoa(tv.Number),
 			PrefetchCondition: condition.Name,
@@ -182,7 +182,7 @@ func TestClient_WAFs(t *testing.T) {
 	}()
 	var uwaf *WAF
 	record(t, fixtureBase+"/update", func(c *Client) {
-		uwaf, err = c.UpdateWAF(&WAFInput{
+		uwaf, err = c.UpdateWAF(&UpdateWAFInput{
 			Service:  testService.ID,
 			Version:  strconv.Itoa(tv.Number),
 			ID:       waf.ID,
@@ -211,14 +211,14 @@ func TestClient_WAFs(t *testing.T) {
 
 func TestClient_CreateWAF_validation(t *testing.T) {
 	var err error
-	_, err = testClient.CreateWAF(&WAFInput{
+	_, err = testClient.CreateWAF(&CreateWAFInput{
 		Service: "",
 	})
 	if err != ErrMissingService {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.CreateWAF(&WAFInput{
+	_, err = testClient.CreateWAF(&CreateWAFInput{
 		Service: "foo",
 		Version: "",
 	})
@@ -255,14 +255,14 @@ func TestClient_GetWAF_validation(t *testing.T) {
 
 func TestClient_UpdateWAF_validation(t *testing.T) {
 	var err error
-	_, err = testClient.UpdateWAF(&WAFInput{
+	_, err = testClient.UpdateWAF(&UpdateWAFInput{
 		Service: "",
 	})
 	if err != ErrMissingService {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateWAF(&WAFInput{
+	_, err = testClient.UpdateWAF(&UpdateWAFInput{
 		Service: "foo",
 		Version: "",
 	})
@@ -270,7 +270,7 @@ func TestClient_UpdateWAF_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateWAF(&WAFInput{
+	_, err = testClient.UpdateWAF(&UpdateWAFInput{
 		Service: "foo",
 		Version: "1",
 		ID:      "",

--- a/fastly/waf_test.go
+++ b/fastly/waf_test.go
@@ -270,60 +270,50 @@ func TestClient_GetWAF_validation(t *testing.T) {
 	}
 }
 
-//
-// func TestClient_UpdateWAF_validation(t *testing.T) {
-// 	var err error
-// 	_, err = testClient.UpdateWAF(&UpdateWAFInput{
-// 		Service: "",
-// 	})
-// 	if err != ErrMissingService {
-// 		t.Errorf("bad error: %s", err)
-// 	}
-//
-// 	_, err = testClient.UpdateWAF(&UpdateWAFInput{
-// 		Service: "foo",
-// 		Version: 0,
-// 	})
-// 	if err != ErrMissingVersion {
-// 		t.Errorf("bad error: %s", err)
-// 	}
-//
-// 	_, err = testClient.UpdateWAF(&UpdateWAFInput{
-// 		Service: "foo",
-// 		Version: 1,
-// 		WAFID:   "",
-// 	})
-// 	if err != ErrMissingWAFID {
-// 		t.Errorf("bad error: %s", err)
-// 	}
-// }
-//
-// func TestClient_DeleteWAF_validation(t *testing.T) {
-// 	var err error
-// 	err = testClient.DeleteWAF(&DeleteWAFInput{
-// 		Service: "",
-// 	})
-// 	if err != ErrMissingService {
-// 		t.Errorf("bad error: %s", err)
-// 	}
-//
-// 	err = testClient.DeleteWAF(&DeleteWAFInput{
-// 		Service: "foo",
-// 		Version: 0,
-// 	})
-// 	if err != ErrMissingVersion {
-// 		t.Errorf("bad error: %s", err)
-// 	}
-//
-// 	err = testClient.DeleteWAF(&DeleteWAFInput{
-// 		Service: "foo",
-// 		Version: 1,
-// 		WAFID:   "",
-// 	})
-// 	if err != ErrMissingWAFID {
-// 		t.Errorf("bad error: %s", err)
-// 	}
-// }
+func TestClient_UpdateWAF_validation(t *testing.T) {
+	var err error
+	_, err = testClient.UpdateWAF(&WAFInput{
+		Service: "",
+	})
+	if err != ErrMissingService {
+		t.Errorf("bad error: %s", err)
+	}
+
+	_, err = testClient.UpdateWAF(&WAFInput{
+		Service: "foo",
+		Version: "",
+	})
+	if err != ErrMissingVersion {
+		t.Errorf("bad error: %s", err)
+	}
+
+	_, err = testClient.UpdateWAF(&WAFInput{
+		Service: "foo",
+		Version: "1",
+		ID:      "",
+	})
+	if err != ErrMissingWAFID {
+		t.Errorf("bad error: %s", err)
+	}
+}
+
+func TestClient_DeleteWAF_validation(t *testing.T) {
+	var err error
+	err = testClient.DeleteWAF(&DeleteWAFInput{
+		Version: "",
+	})
+	if err != ErrMissingVersion {
+		t.Errorf("bad error: %s", err)
+	}
+
+	err = testClient.DeleteWAF(&DeleteWAFInput{
+		Version: "1",
+		ID:      "",
+	})
+	if err != ErrMissingWAFID {
+		t.Errorf("bad error: %s", err)
+	}
+}
 
 func TestUpdateWAFRuleStatusesInput_validate(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
This PR contains the implementation of the service's waf component endpoints for the new API. Note that only endpoints related to the service waf block have been implemented, leaving the rest of the code using the old API, with the exception of enabling/disabling waf which has been created but no test coverage yet. Test coverage for enabling/disabling waf will be addressed within the waf configuration resource scope.   