### PR TITLE
Service waf component

### DIFF
--- a/fastly/client.go
+++ b/fastly/client.go
@@ -190,6 +190,11 @@ func (c *Client) Delete(p string, ro *RequestOptions) (*http.Response, error) {
 	return c.Request("DELETE", p, ro)
 }
 
+// DeleteJSON issues an HTTP DELETE request.
+func (c *Client) DeleteJSON(p string, i interface{}, ro *RequestOptions) (*http.Response, error) {
+	return c.RequestJSONAPI("DELETE", p, i, ro)
+}
+
 // Request makes an HTTP request against the HTTPClient using the given verb,
 // Path, and request options.
 func (c *Client) Request(verb, p string, ro *RequestOptions) (*http.Response, error) {

--- a/fastly/fixtures/wafs/cleanup.yaml
+++ b/fastly/fixtures/wafs/cleanup.yaml
@@ -1,40 +1,41 @@
 ---
 version: 1
-rwmutex: {}
 interactions:
 - request:
-    body: ""
+    body: |
+      {"data":{"type":"waf_firewall","id":"59onHkuKX28AMcf0gOojis","attributes":{"service_version_number":"2"}}}
     form: {}
     headers:
-      Fastly-Key:
-      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+      Accept:
+      - application/vnd.api+json
+      Content-Type:
+      - application/vnd.api+json
       User-Agent:
-      - FastlyGo/0.4.3.dev (+github.com/fastly/go-fastly; go1.12)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/54/wafs/2WK9ofHfHcPi3s6S2X0Z8m
+      - FastlyGo/1.3.0 (+github.com/fastly/go-fastly; go1.13.4)
+    url: https://api.fastly.com/waf/firewalls/59onHkuKX28AMcf0gOojis
     method: DELETE
   response:
-    body: ""
+    body: '{"errors":[{"title":"Resource not found","detail":"We could not find a
+      resource matching the one in your request"}]}'
     headers:
       Accept-Ranges:
       - bytes
       Date:
-      - Sat, 11 May 2019 21:45:03 GMT
+      - Tue, 12 Nov 2019 16:10:25 GMT
       Status:
-      - 204 No Content
+      - 404 Not Found
       Strict-Transport-Security:
       - max-age=31536000
       Via:
-      - 1.1 varnish
       - 1.1 varnish
       X-Cache:
       - MISS, MISS
       X-Cache-Hits:
       - 0, 0
-      X-Content-Type-Options:
-      - nosniff
       X-Served-By:
-      - cache-control-slwdc9035-CONTROL-SLWDC, cache-lax8631-LAX
+      - cache-control-slwdc9036-CONTROL-SLWDC, cache-lcy19279-LCY
       X-Timer:
-      - S1557611103.468691,VS0,VE153
-    status: 204 No Content
-    code: 204
+      - S1573575025.472733,VS0,VE128
+    status: 404 Not Found
+    code: 404
+    duration: ""

--- a/fastly/fixtures/wafs/condition/create.yaml
+++ b/fastly/fixtures/wafs/condition/create.yaml
@@ -1,16 +1,15 @@
 ---
 version: 1
-rwmutex: {}
 interactions:
 - request:
-    body: Service=7i6HN3TK9wS159v2gPAZ8A&Version=54&name=test-waf-condition&priority=1&statement=req.url~%2B%22index.html%22&type=PREFETCH
+    body: Service=6gkEdARZ3mPzhQvdi2YH3j&Version=2&name=WAF_Prefetch&priority=1&statement=req.url~%2B%22index.html%22&type=PREFETCH
     form:
       Service:
-      - 7i6HN3TK9wS159v2gPAZ8A
+      - 6gkEdARZ3mPzhQvdi2YH3j
       Version:
-      - "54"
+      - "2"
       name:
-      - test-waf-condition
+      - WAF_Prefetch
       priority:
       - "1"
       statement:
@@ -20,14 +19,12 @@ interactions:
     headers:
       Content-Type:
       - application/x-www-form-urlencoded
-      Fastly-Key:
-      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
-      - FastlyGo/0.4.3.dev (+github.com/fastly/go-fastly; go1.12)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/54/condition
+      - FastlyGo/1.3.0 (+github.com/fastly/go-fastly; go1.13.4)
+    url: https://api.fastly.com/service/6gkEdARZ3mPzhQvdi2YH3j/version/2/condition
     method: POST
   response:
-    body: '{"name":"test-waf-condition","priority":"1","statement":"req.url~+\"index.html\"","type":"PREFETCH","service_id":"7i6HN3TK9wS159v2gPAZ8A","version":"54","created_at":"2019-05-11T21:44:59Z","updated_at":"2019-05-11T21:44:59Z","deleted_at":null,"comment":""}'
+    body: '{"name":"WAF_Prefetch","priority":"1","statement":"req.url~+\"index.html\"","type":"PREFETCH","service_id":"6gkEdARZ3mPzhQvdi2YH3j","version":"2","comment":"","deleted_at":null,"updated_at":"2019-11-12T16:10:22Z","created_at":"2019-11-12T16:10:22Z"}'
     headers:
       Accept-Ranges:
       - bytes
@@ -36,11 +33,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sat, 11 May 2019 21:44:59 GMT
+      - Tue, 12 Nov 2019 16:10:22 GMT
       Fastly-Ratelimit-Remaining:
-      - "990"
+      - "974"
       Fastly-Ratelimit-Reset:
-      - "1557612000"
+      - "1573578000"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -49,14 +46,14 @@ interactions:
       - Accept-Encoding
       Via:
       - 1.1 varnish
-      - 1.1 varnish
       X-Cache:
       - MISS, MISS
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9037-CONTROL-SLWDC, cache-lax8631-LAX
+      - cache-control-slwdc9037-CONTROL-SLWDC, cache-lcy19279-LCY
       X-Timer:
-      - S1557611099.476242,VS0,VE199
+      - S1573575022.958487,VS0,VE181
     status: 200 OK
     code: 200
+    duration: ""

--- a/fastly/fixtures/wafs/create.yaml
+++ b/fastly/fixtures/wafs/create.yaml
@@ -1,39 +1,35 @@
 ---
 version: 1
-rwmutex: {}
 interactions:
 - request:
     body: |
-      {"data":{"type":"waf","attributes":{"prefetch_condition":"test-waf-condition","response":"test-response-object"}}}
+      {"data":{"type":"waf_firewall","attributes":{"prefetch_condition":"WAF_Prefetch","response":"WAf_Response","service_id":"6gkEdARZ3mPzhQvdi2YH3j","service_version_number":"2"}}}
     form: {}
     headers:
       Accept:
       - application/vnd.api+json
       Content-Type:
       - application/vnd.api+json
-      Fastly-Key:
-      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
-      - FastlyGo/0.4.3.dev (+github.com/fastly/go-fastly; go1.12)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/54/wafs
+      - FastlyGo/1.3.0 (+github.com/fastly/go-fastly; go1.13.4)
+    url: https://api.fastly.com/waf/firewalls
     method: POST
   response:
-    body: '{"data":{"id":"2WK9ofHfHcPi3s6S2X0Z8m","type":"waf","attributes":{"last_push":null,"prefetch_condition":"test-waf-condition","response":"test-response-object","version":54,"service_id":"7i6HN3TK9wS159v2gPAZ8A","disabled":false,"rule_statuses_log_count":0,"rule_statuses_block_count":0,"rule_statuses_disabled_count":0},"relationships":{"configuration_set":{"data":{"id":"3vnl3cwPda9Q3WYCDRuGW","type":"configuration_set"}},"owasp":{"data":{"id":"4Jh5ZWRaYGgPdCdgQZNzyk","type":"owasp"}}}}}'
+    body: '{"data":{"id":"59onHkuKX28AMcf0gOojis","type":"waf_firewall","attributes":{"service_id":"6gkEdARZ3mPzhQvdi2YH3j","prefetch_condition":"WAF_Prefetch","response":"WAf_Response","disabled":false,"service_version_number":2,"created_at":"2019-11-12T16:10:23Z","updated_at":"2019-11-12T16:10:23Z","active_rules_trustwave_log_count":0,"active_rules_trustwave_block_count":0,"active_rules_fastly_log_count":0,"active_rules_fastly_block_count":0,"active_rules_owasp_log_count":0,"active_rules_owasp_block_count":0,"active_rules_owasp_score_count":0}}}'
     headers:
       Accept-Ranges:
       - bytes
       Content-Length:
-      - "489"
+      - "542"
       Content-Type:
       - application/vnd.api+json
       Date:
-      - Sat, 11 May 2019 21:45:00 GMT
+      - Tue, 12 Nov 2019 16:10:23 GMT
       Status:
-      - 200 OK
+      - 201 Created
       Strict-Transport-Security:
       - max-age=31536000
       Via:
-      - 1.1 varnish
       - 1.1 varnish
       X-Cache:
       - MISS, MISS
@@ -42,8 +38,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Served-By:
-      - cache-control-slwdc9035-CONTROL-SLWDC, cache-lax8631-LAX
+      - cache-control-slwdc9036-CONTROL-SLWDC, cache-lcy19279-LCY
       X-Timer:
-      - S1557611100.058242,VS0,VE742
-    status: 200 OK
-    code: 200
+      - S1573575023.603740,VS0,VE737
+    status: 201 Created
+    code: 201
+    duration: ""

--- a/fastly/fixtures/wafs/create_service.yaml
+++ b/fastly/fixtures/wafs/create_service.yaml
@@ -1,0 +1,51 @@
+---
+version: 1
+interactions:
+- request:
+    body: comment=go-fastly+client+test&name=test_service_service
+    form:
+      comment:
+      - go-fastly client test
+      name:
+      - test_service_service
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - FastlyGo/1.3.0 (+github.com/fastly/go-fastly; go1.13.4)
+    url: https://api.fastly.com/service
+    method: POST
+  response:
+    body: '{"customer_id":"WpqWFjTA4lk2N1g0GY2HH","comment":"go-fastly client test","name":"test_service_service","publish_key":"3b94816c86b3a740fe97cbfa2c1f24d00a3317d8","deleted_at":null,"created_at":"2019-11-12T16:10:20Z","updated_at":"2019-11-12T16:10:20Z","id":"6gkEdARZ3mPzhQvdi2YH3j","type":"vcl","versions":[{"service_id":"6gkEdARZ3mPzhQvdi2YH3j","deployed":false,"staging":false,"active":false,"updated_at":"2019-11-12T16:10:20Z","created_at":"2019-11-12T16:10:20Z","locked":false,"deleted_at":null,"testing":false,"number":1,"comment":""}]}'
+    headers:
+      Accept-Ranges:
+      - bytes
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 12 Nov 2019 16:10:20 GMT
+      Fastly-Ratelimit-Remaining:
+      - "977"
+      Fastly-Ratelimit-Reset:
+      - "1573578000"
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 varnish
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Served-By:
+      - cache-control-slwdc9035-CONTROL-SLWDC, cache-lcy19279-LCY
+      X-Timer:
+      - S1573575020.114176,VS0,VE526
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/fastly/fixtures/wafs/delete.yaml
+++ b/fastly/fixtures/wafs/delete.yaml
@@ -1,16 +1,18 @@
 ---
 version: 1
-rwmutex: {}
 interactions:
 - request:
-    body: ""
+    body: |
+      {"data":{"type":"waf_firewall","id":"59onHkuKX28AMcf0gOojis","attributes":{"service_version_number":"2"}}}
     form: {}
     headers:
-      Fastly-Key:
-      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+      Accept:
+      - application/vnd.api+json
+      Content-Type:
+      - application/vnd.api+json
       User-Agent:
-      - FastlyGo/0.4.3.dev (+github.com/fastly/go-fastly; go1.12)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/54/wafs/2WK9ofHfHcPi3s6S2X0Z8m
+      - FastlyGo/1.3.0 (+github.com/fastly/go-fastly; go1.13.4)
+    url: https://api.fastly.com/waf/firewalls/59onHkuKX28AMcf0gOojis
     method: DELETE
   response:
     body: ""
@@ -18,13 +20,12 @@ interactions:
       Accept-Ranges:
       - bytes
       Date:
-      - Sat, 11 May 2019 21:45:02 GMT
+      - Tue, 12 Nov 2019 16:10:24 GMT
       Status:
       - 204 No Content
       Strict-Transport-Security:
       - max-age=31536000
       Via:
-      - 1.1 varnish
       - 1.1 varnish
       X-Cache:
       - MISS, MISS
@@ -33,8 +34,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Served-By:
-      - cache-control-slwdc9035-CONTROL-SLWDC, cache-lax8631-LAX
+      - cache-control-slwdc9037-CONTROL-SLWDC, cache-lcy19279-LCY
       X-Timer:
-      - S1557611103.608075,VS0,VE254
+      - S1573575025.533117,VS0,VE317
     status: 204 No Content
     code: 204
+    duration: ""

--- a/fastly/fixtures/wafs/delete_service.yaml
+++ b/fastly/fixtures/wafs/delete_service.yaml
@@ -7,7 +7,7 @@ interactions:
     headers:
       User-Agent:
       - FastlyGo/1.3.0 (+github.com/fastly/go-fastly; go1.13.4)
-    url: https://api.fastly.com/service/6gkEdARZ3mPzhQvdi2YH3j/version/2/condition/WAF_Prefetch
+    url: https://api.fastly.com/service/6gkEdARZ3mPzhQvdi2YH3j
     method: DELETE
   response:
     body: '{"status":"ok"}'
@@ -19,9 +19,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 12 Nov 2019 16:10:26 GMT
+      - Tue, 12 Nov 2019 16:10:27 GMT
       Fastly-Ratelimit-Remaining:
-      - "969"
+      - "967"
       Fastly-Ratelimit-Reset:
       - "1573578000"
       Status:
@@ -37,9 +37,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9035-CONTROL-SLWDC, cache-lcy19279-LCY
+      - cache-control-slwdc9036-CONTROL-SLWDC, cache-lcy19279-LCY
       X-Timer:
-      - S1573575026.978734,VS0,VE248
+      - S1573575027.804178,VS0,VE215
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/wafs/get.yaml
+++ b/fastly/fixtures/wafs/get.yaml
@@ -1,36 +1,32 @@
 ---
 version: 1
-rwmutex: {}
 interactions:
 - request:
     body: ""
     form: {}
     headers:
-      Fastly-Key:
-      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
-      - FastlyGo/0.4.3.dev (+github.com/fastly/go-fastly; go1.12)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/54/wafs/2WK9ofHfHcPi3s6S2X0Z8m
+      - FastlyGo/1.3.0 (+github.com/fastly/go-fastly; go1.13.4)
+    url: https://api.fastly.com/waf/firewalls/59onHkuKX28AMcf0gOojis?filter%5Bservice_version_number%5D=2
     method: GET
   response:
-    body: '{"data":{"id":"2WK9ofHfHcPi3s6S2X0Z8m","type":"waf","attributes":{"last_push":null,"prefetch_condition":"test-waf-condition","response":"test-response-object","version":54,"service_id":"7i6HN3TK9wS159v2gPAZ8A","disabled":false,"rule_statuses_log_count":0,"rule_statuses_block_count":0,"rule_statuses_disabled_count":0},"relationships":{"configuration_set":{"data":{"id":"3vnl3cwPda9Q3WYCDRuGW","type":"configuration_set"}}}}}'
+    body: '{"data":{"id":"59onHkuKX28AMcf0gOojis","type":"waf_firewall","attributes":{"service_id":"6gkEdARZ3mPzhQvdi2YH3j","prefetch_condition":"WAF_Prefetch","response":"WAf_Response","disabled":false,"service_version_number":2,"created_at":"2019-11-12T16:10:23Z","updated_at":"2019-11-12T16:10:23Z","active_rules_trustwave_log_count":0,"active_rules_trustwave_block_count":0,"active_rules_fastly_log_count":0,"active_rules_fastly_block_count":0,"active_rules_owasp_log_count":0,"active_rules_owasp_block_count":0,"active_rules_owasp_score_count":0}}}'
     headers:
       Accept-Ranges:
       - bytes
       Age:
       - "0"
       Content-Length:
-      - "425"
+      - "542"
       Content-Type:
       - application/vnd.api+json
       Date:
-      - Sat, 11 May 2019 21:45:01 GMT
+      - Tue, 12 Nov 2019 16:10:23 GMT
       Status:
       - 200 OK
       Strict-Transport-Security:
       - max-age=31536000
       Via:
-      - 1.1 varnish
       - 1.1 varnish
       X-Cache:
       - MISS, MISS
@@ -39,8 +35,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Served-By:
-      - cache-control-slwdc9037-CONTROL-SLWDC, cache-lax8631-LAX
+      - cache-control-slwdc9036-CONTROL-SLWDC, cache-lcy19279-LCY
       X-Timer:
-      - S1557611101.328100,VS0,VE372
+      - S1573575024.630073,VS0,VE173
     status: 200 OK
     code: 200
+    duration: ""

--- a/fastly/fixtures/wafs/list.yaml
+++ b/fastly/fixtures/wafs/list.yaml
@@ -1,36 +1,32 @@
 ---
 version: 1
-rwmutex: {}
 interactions:
 - request:
     body: ""
     form: {}
     headers:
-      Fastly-Key:
-      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
-      - FastlyGo/0.4.3.dev (+github.com/fastly/go-fastly; go1.12)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/54/wafs
+      - FastlyGo/1.3.0 (+github.com/fastly/go-fastly; go1.13.4)
+    url: https://api.fastly.com/waf/firewalls?filter%5Bservice_id%5D=6gkEdARZ3mPzhQvdi2YH3j&filter%5Bservice_version_number%5D=2
     method: GET
   response:
-    body: '{"data":[{"id":"2WK9ofHfHcPi3s6S2X0Z8m","type":"waf","attributes":{"last_push":null,"prefetch_condition":"test-waf-condition","response":"test-response-object","version":54,"service_id":"7i6HN3TK9wS159v2gPAZ8A","disabled":false,"rule_statuses_log_count":0,"rule_statuses_block_count":0,"rule_statuses_disabled_count":0}}],"links":{"last":"https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/54/wafs?page[number]=1\u0026page[size]=100","first":"https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/54/wafs?page[number]=1\u0026page[size]=100"},"meta":{"current_page":1,"per_page":100,"record_count":1,"total_pages":1}}'
+    body: '{"data":[{"id":"59onHkuKX28AMcf0gOojis","type":"waf_firewall","attributes":{"service_id":"6gkEdARZ3mPzhQvdi2YH3j","prefetch_condition":"WAF_Prefetch","response":"WAf_Response","disabled":false,"service_version_number":2,"created_at":"2019-11-12T16:10:23Z","updated_at":"2019-11-12T16:10:23Z","active_rules_trustwave_log_count":0,"active_rules_trustwave_block_count":0,"active_rules_fastly_log_count":0,"active_rules_fastly_block_count":0,"active_rules_owasp_log_count":0,"active_rules_owasp_block_count":0,"active_rules_owasp_score_count":0}}],"links":{"last":"https://api.fastly.com/waf/firewalls?filter[service_id]=6gkEdARZ3mPzhQvdi2YH3j\u0026filter[service_version_number]=2\u0026page[number]=1\u0026page[size]=100","first":"https://api.fastly.com/waf/firewalls?filter[service_id]=6gkEdARZ3mPzhQvdi2YH3j\u0026filter[service_version_number]=2\u0026page[number]=1\u0026page[size]=100"},"meta":{"current_page":1,"per_page":100,"record_count":1,"total_pages":1}}'
     headers:
       Accept-Ranges:
       - bytes
       Age:
       - "0"
       Content-Length:
-      - "635"
+      - "961"
       Content-Type:
       - application/vnd.api+json
       Date:
-      - Sat, 11 May 2019 21:45:01 GMT
+      - Tue, 12 Nov 2019 16:10:23 GMT
       Status:
       - 200 OK
       Strict-Transport-Security:
       - max-age=31536000
       Via:
-      - 1.1 varnish
       - 1.1 varnish
       X-Cache:
       - MISS, MISS
@@ -39,8 +35,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Served-By:
-      - cache-control-slwdc9036-CONTROL-SLWDC, cache-lax8631-LAX
+      - cache-control-slwdc9036-CONTROL-SLWDC, cache-lcy19279-LCY
       X-Timer:
-      - S1557611101.825257,VS0,VE468
+      - S1573575023.349598,VS0,VE175
     status: 200 OK
     code: 200
+    duration: ""

--- a/fastly/fixtures/wafs/logging/cleanup.yaml
+++ b/fastly/fixtures/wafs/logging/cleanup.yaml
@@ -1,16 +1,13 @@
 ---
 version: 1
-rwmutex: {}
 interactions:
 - request:
     body: ""
     form: {}
     headers:
-      Fastly-Key:
-      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
-      - FastlyGo/0.4.3.dev (+github.com/fastly/go-fastly; go1.12)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/54/logging/syslog/test-syslog
+      - FastlyGo/1.3.0 (+github.com/fastly/go-fastly; go1.13.4)
+    url: https://api.fastly.com/service/6gkEdARZ3mPzhQvdi2YH3j/version/2/logging/syslog/test-syslog
     method: DELETE
   response:
     body: '{"status":"ok"}'
@@ -22,11 +19,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sat, 11 May 2019 21:45:04 GMT
+      - Tue, 12 Nov 2019 16:10:26 GMT
       Fastly-Ratelimit-Remaining:
-      - "984"
+      - "968"
       Fastly-Ratelimit-Reset:
-      - "1557612000"
+      - "1573578000"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -35,14 +32,14 @@ interactions:
       - Accept-Encoding
       Via:
       - 1.1 varnish
-      - 1.1 varnish
       X-Cache:
       - MISS, MISS
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9037-CONTROL-SLWDC, cache-lax8631-LAX
+      - cache-control-slwdc9037-CONTROL-SLWDC, cache-lcy19279-LCY
       X-Timer:
-      - S1557611104.386426,VS0,VE311
+      - S1573575026.284242,VS0,VE480
     status: 200 OK
     code: 200
+    duration: ""

--- a/fastly/fixtures/wafs/logging/create.yaml
+++ b/fastly/fixtures/wafs/logging/create.yaml
@@ -1,14 +1,13 @@
 ---
 version: 1
-rwmutex: {}
 interactions:
 - request:
-    body: Service=7i6HN3TK9wS159v2gPAZ8A&Version=54&address=example.com&format=format&format_version=2&hostname=example.com&message_type=classic&name=test-syslog&port=1234&token=abcd1234
+    body: Service=6gkEdARZ3mPzhQvdi2YH3j&Version=2&address=example.com&format=format&format_version=2&hostname=example.com&message_type=classic&name=test-syslog&port=1234&token=abcd1234
     form:
       Service:
-      - 7i6HN3TK9wS159v2gPAZ8A
+      - 6gkEdARZ3mPzhQvdi2YH3j
       Version:
-      - "54"
+      - "2"
       address:
       - example.com
       format:
@@ -28,14 +27,12 @@ interactions:
     headers:
       Content-Type:
       - application/x-www-form-urlencoded
-      Fastly-Key:
-      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
-      - FastlyGo/0.4.3.dev (+github.com/fastly/go-fastly; go1.12)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/54/logging/syslog
+      - FastlyGo/1.3.0 (+github.com/fastly/go-fastly; go1.13.4)
+    url: https://api.fastly.com/service/6gkEdARZ3mPzhQvdi2YH3j/version/2/logging/syslog
     method: POST
   response:
-    body: '{"address":"example.com","format":"format","format_version":"2","hostname":"example.com","message_type":"classic","name":"test-syslog","port":"1234","token":"abcd1234","service_id":"7i6HN3TK9wS159v2gPAZ8A","version":"54","tls_hostname":null,"use_tls":"0","created_at":"2019-05-11T21:44:58Z","response_condition":"","updated_at":"2019-05-11T21:44:59Z","tls_ca_cert":null,"placement":null,"deleted_at":null,"ipv4":null,"public_key":null}'
+    body: '{"address":"example.com","format":"format","format_version":"2","hostname":"example.com","message_type":"classic","name":"test-syslog","port":"1234","token":"abcd1234","service_id":"6gkEdARZ3mPzhQvdi2YH3j","version":"2","tls_hostname":null,"public_key":null,"use_tls":"0","deleted_at":null,"response_condition":"","tls_ca_cert":null,"placement":null,"updated_at":"2019-11-12T16:10:21Z","ipv4":null,"created_at":"2019-11-12T16:10:21Z","tls_client_cert":null,"tls_client_key":null}'
     headers:
       Accept-Ranges:
       - bytes
@@ -44,11 +41,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sat, 11 May 2019 21:44:59 GMT
+      - Tue, 12 Nov 2019 16:10:21 GMT
       Fastly-Ratelimit-Remaining:
-      - "991"
+      - "975"
       Fastly-Ratelimit-Reset:
-      - "1557612000"
+      - "1573578000"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -57,14 +54,14 @@ interactions:
       - Accept-Encoding
       Via:
       - 1.1 varnish
-      - 1.1 varnish
       X-Cache:
       - MISS, MISS
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9035-CONTROL-SLWDC, cache-lax8631-LAX
+      - cache-control-slwdc9036-CONTROL-SLWDC, cache-lcy19279-LCY
       X-Timer:
-      - S1557611099.652892,VS0,VE682
+      - S1573575021.168593,VS0,VE780
     status: 200 OK
     code: 200
+    duration: ""

--- a/fastly/fixtures/wafs/response_object/cleanup.yaml
+++ b/fastly/fixtures/wafs/response_object/cleanup.yaml
@@ -1,16 +1,13 @@
 ---
 version: 1
-rwmutex: {}
 interactions:
 - request:
     body: ""
     form: {}
     headers:
-      Fastly-Key:
-      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
-      - FastlyGo/0.4.3.dev (+github.com/fastly/go-fastly; go1.12)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/54/response_object/test-response-object
+      - FastlyGo/1.3.0 (+github.com/fastly/go-fastly; go1.13.4)
+    url: https://api.fastly.com/service/6gkEdARZ3mPzhQvdi2YH3j/version/2/response_object/WAf_Response
     method: DELETE
   response:
     body: '{"status":"ok"}'
@@ -22,11 +19,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sat, 11 May 2019 21:45:03 GMT
+      - Tue, 12 Nov 2019 16:10:25 GMT
       Fastly-Ratelimit-Remaining:
-      - "986"
+      - "970"
       Fastly-Ratelimit-Reset:
-      - "1557612000"
+      - "1573578000"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -35,14 +32,14 @@ interactions:
       - Accept-Encoding
       Via:
       - 1.1 varnish
-      - 1.1 varnish
       X-Cache:
       - MISS, MISS
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9035-CONTROL-SLWDC, cache-lax8631-LAX
+      - cache-control-slwdc9036-CONTROL-SLWDC, cache-lcy19279-LCY
       X-Timer:
-      - S1557611104.646216,VS0,VE312
+      - S1573575026.606832,VS0,VE339
     status: 200 OK
     code: 200
+    duration: ""

--- a/fastly/fixtures/wafs/response_object/cleanup_another.yaml
+++ b/fastly/fixtures/wafs/response_object/cleanup_another.yaml
@@ -1,16 +1,13 @@
 ---
 version: 1
-rwmutex: {}
 interactions:
 - request:
     body: ""
     form: {}
     headers:
-      Fastly-Key:
-      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
-      - FastlyGo/0.4.3.dev (+github.com/fastly/go-fastly; go1.12)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/54/response_object/test-response-object-2
+      - FastlyGo/1.3.0 (+github.com/fastly/go-fastly; go1.13.4)
+    url: https://api.fastly.com/service/6gkEdARZ3mPzhQvdi2YH3j/version/2/response_object/test-response-object-2
     method: DELETE
   response:
     body: '{"status":"ok"}'
@@ -22,11 +19,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sat, 11 May 2019 21:45:03 GMT
+      - Tue, 12 Nov 2019 16:10:25 GMT
       Fastly-Ratelimit-Remaining:
-      - "987"
+      - "971"
       Fastly-Ratelimit-Reset:
-      - "1557612000"
+      - "1573578000"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -35,14 +32,14 @@ interactions:
       - Accept-Encoding
       Via:
       - 1.1 varnish
-      - 1.1 varnish
       X-Cache:
       - MISS, MISS
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9036-CONTROL-SLWDC, cache-lax8631-LAX
+      - cache-control-slwdc9035-CONTROL-SLWDC, cache-lcy19279-LCY
       X-Timer:
-      - S1557611103.897977,VS0,VE289
+      - S1573575025.955392,VS0,VE478
     status: 200 OK
     code: 200
+    duration: ""

--- a/fastly/fixtures/wafs/response_object/create.yaml
+++ b/fastly/fixtures/wafs/response_object/create.yaml
@@ -1,20 +1,19 @@
 ---
 version: 1
-rwmutex: {}
 interactions:
 - request:
-    body: Service=7i6HN3TK9wS159v2gPAZ8A&Version=54&content=abcd&content_type=text%2Fplain&name=test-response-object&response=Ok&status=200
+    body: Service=6gkEdARZ3mPzhQvdi2YH3j&Version=2&content=abcd&content_type=text%2Fplain&name=WAf_Response&response=Ok&status=200
     form:
       Service:
-      - 7i6HN3TK9wS159v2gPAZ8A
+      - 6gkEdARZ3mPzhQvdi2YH3j
       Version:
-      - "54"
+      - "2"
       content:
       - abcd
       content_type:
       - text/plain
       name:
-      - test-response-object
+      - WAf_Response
       response:
       - Ok
       status:
@@ -22,14 +21,12 @@ interactions:
     headers:
       Content-Type:
       - application/x-www-form-urlencoded
-      Fastly-Key:
-      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
-      - FastlyGo/0.4.3.dev (+github.com/fastly/go-fastly; go1.12)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/54/response_object
+      - FastlyGo/1.3.0 (+github.com/fastly/go-fastly; go1.13.4)
+    url: https://api.fastly.com/service/6gkEdARZ3mPzhQvdi2YH3j/version/2/response_object
     method: POST
   response:
-    body: '{"content":"abcd","content_type":"text/plain","name":"test-response-object","response":"Ok","status":"200","service_id":"7i6HN3TK9wS159v2gPAZ8A","version":"54","deleted_at":null,"created_at":"2019-05-11T21:44:59Z","request_condition":"","updated_at":"2019-05-11T21:44:59Z","cache_condition":""}'
+    body: '{"content":"abcd","content_type":"text/plain","name":"WAf_Response","response":"Ok","status":"200","service_id":"6gkEdARZ3mPzhQvdi2YH3j","version":"2","created_at":"2019-11-12T16:10:22Z","deleted_at":null,"updated_at":"2019-11-12T16:10:22Z","cache_condition":"","request_condition":""}'
     headers:
       Accept-Ranges:
       - bytes
@@ -38,11 +35,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sat, 11 May 2019 21:45:00 GMT
+      - Tue, 12 Nov 2019 16:10:22 GMT
       Fastly-Ratelimit-Remaining:
-      - "989"
+      - "973"
       Fastly-Ratelimit-Reset:
-      - "1557612000"
+      - "1573578000"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -51,14 +48,14 @@ interactions:
       - Accept-Encoding
       Via:
       - 1.1 varnish
-      - 1.1 varnish
       X-Cache:
       - MISS, MISS
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9035-CONTROL-SLWDC, cache-lax8631-LAX
+      - cache-control-slwdc9037-CONTROL-SLWDC, cache-lcy19279-LCY
       X-Timer:
-      - S1557611100.704714,VS0,VE321
+      - S1573575022.149894,VS0,VE343
     status: 200 OK
     code: 200
+    duration: ""

--- a/fastly/fixtures/wafs/response_object/create_another.yaml
+++ b/fastly/fixtures/wafs/response_object/create_another.yaml
@@ -1,14 +1,13 @@
 ---
 version: 1
-rwmutex: {}
 interactions:
 - request:
-    body: Service=7i6HN3TK9wS159v2gPAZ8A&Version=54&content=efgh&content_type=text%2Fplain&name=test-response-object-2&response=Ok&status=200
+    body: Service=6gkEdARZ3mPzhQvdi2YH3j&Version=2&content=efgh&content_type=text%2Fplain&name=test-response-object-2&response=Ok&status=200
     form:
       Service:
-      - 7i6HN3TK9wS159v2gPAZ8A
+      - 6gkEdARZ3mPzhQvdi2YH3j
       Version:
-      - "54"
+      - "2"
       content:
       - efgh
       content_type:
@@ -22,14 +21,12 @@ interactions:
     headers:
       Content-Type:
       - application/x-www-form-urlencoded
-      Fastly-Key:
-      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
-      - FastlyGo/0.4.3.dev (+github.com/fastly/go-fastly; go1.12)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/54/response_object
+      - FastlyGo/1.3.0 (+github.com/fastly/go-fastly; go1.13.4)
+    url: https://api.fastly.com/service/6gkEdARZ3mPzhQvdi2YH3j/version/2/response_object
     method: POST
   response:
-    body: '{"content":"efgh","content_type":"text/plain","name":"test-response-object-2","response":"Ok","status":"200","service_id":"7i6HN3TK9wS159v2gPAZ8A","version":"54","cache_condition":"","created_at":"2019-05-11T21:45:01Z","request_condition":"","deleted_at":null,"updated_at":"2019-05-11T21:45:01Z"}'
+    body: '{"content":"efgh","content_type":"text/plain","name":"test-response-object-2","response":"Ok","status":"200","service_id":"6gkEdARZ3mPzhQvdi2YH3j","version":"2","deleted_at":null,"updated_at":"2019-11-12T16:10:24Z","request_condition":"","created_at":"2019-11-12T16:10:24Z","cache_condition":""}'
     headers:
       Accept-Ranges:
       - bytes
@@ -38,11 +35,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sat, 11 May 2019 21:45:01 GMT
+      - Tue, 12 Nov 2019 16:10:24 GMT
       Fastly-Ratelimit-Remaining:
-      - "988"
+      - "972"
       Fastly-Ratelimit-Reset:
-      - "1557612000"
+      - "1573578000"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -51,14 +48,14 @@ interactions:
       - Accept-Encoding
       Via:
       - 1.1 varnish
-      - 1.1 varnish
       X-Cache:
       - MISS, MISS
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9037-CONTROL-SLWDC, cache-lax8631-LAX
+      - cache-control-slwdc9037-CONTROL-SLWDC, cache-lcy19279-LCY
       X-Timer:
-      - S1557611102.735005,VS0,VE257
+      - S1573575024.828564,VS0,VE366
     status: 200 OK
     code: 200
+    duration: ""

--- a/fastly/fixtures/wafs/update.yaml
+++ b/fastly/fixtures/wafs/update.yaml
@@ -1,26 +1,23 @@
 ---
 version: 1
-rwmutex: {}
 interactions:
 - request:
     body: |
-      {"data":{"type":"waf","id":"2WK9ofHfHcPi3s6S2X0Z8m","attributes":{"response":"test-response-object-2"}}}
+      {"data":{"type":"waf_firewall","id":"59onHkuKX28AMcf0gOojis","attributes":{"prefetch_condition":"","response":"test-response-object-2","service_id":"6gkEdARZ3mPzhQvdi2YH3j","service_version_number":"2"}}}
     form: {}
     headers:
       Accept:
       - application/vnd.api+json
       Content-Type:
       - application/vnd.api+json
-      Fastly-Key:
-      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
-      - FastlyGo/0.4.3.dev (+github.com/fastly/go-fastly; go1.12)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/54/wafs/2WK9ofHfHcPi3s6S2X0Z8m
+      - FastlyGo/1.3.0 (+github.com/fastly/go-fastly; go1.13.4)
+    url: https://api.fastly.com/waf/firewalls/59onHkuKX28AMcf0gOojis
     method: PATCH
   response:
-    body: '{"data":{"id":"2WK9ofHfHcPi3s6S2X0Z8m","type":"waf","attributes":{"last_push":null,"prefetch_condition":"test-waf-condition","response":"test-response-object-2","version":54,"service_id":"7i6HN3TK9wS159v2gPAZ8A","disabled":false,"rule_statuses_log_count":0,"rule_statuses_block_count":0,"rule_statuses_disabled_count":0},"relationships":{"configuration_set":{"data":{"id":"3vnl3cwPda9Q3WYCDRuGW","type":"configuration_set"}},"owasp":{"data":{"id":"4Jh5ZWRaYGgPdCdgQZNzyk","type":"owasp"}}}},"meta":{"warnings":[{"title":"This
+    body: '{"data":{"id":"59onHkuKX28AMcf0gOojis","type":"waf_firewall","attributes":{"service_id":"6gkEdARZ3mPzhQvdi2YH3j","prefetch_condition":"","response":"test-response-object-2","disabled":false,"service_version_number":2,"created_at":"2019-11-12T16:10:23Z","updated_at":"2019-11-12T16:10:23Z","active_rules_trustwave_log_count":0,"active_rules_trustwave_block_count":0,"active_rules_fastly_log_count":0,"active_rules_fastly_block_count":0,"active_rules_owasp_log_count":0,"active_rules_owasp_block_count":0,"active_rules_owasp_score_count":0}},"meta":{"warnings":[{"title":"This
       version of this service must be active","detail":"You may only update the WAF
-      VCL on an active version of a service.  The version 54 of service 7i6HN3TK9wS159v2gPAZ8A
+      VCL on an active version of a service.  The version 2 of service 6gkEdARZ3mPzhQvdi2YH3j
       is not active.  You may activate it through https://app.fastly.com or through
       the API: https://docs.fastly.com/api/config#version  Be sure to review the version''s
       changes before activating it."}]}}'
@@ -28,17 +25,16 @@ interactions:
       Accept-Ranges:
       - bytes
       Content-Length:
-      - "890"
+      - "938"
       Content-Type:
       - application/vnd.api+json
       Date:
-      - Sat, 11 May 2019 21:45:02 GMT
+      - Tue, 12 Nov 2019 16:10:24 GMT
       Status:
       - 200 OK
       Strict-Transport-Security:
       - max-age=31536000
       Via:
-      - 1.1 varnish
       - 1.1 varnish
       X-Cache:
       - MISS, MISS
@@ -47,8 +43,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Served-By:
-      - cache-control-slwdc9036-CONTROL-SLWDC, cache-lax8631-LAX
+      - cache-control-slwdc9035-CONTROL-SLWDC, cache-lcy19279-LCY
       X-Timer:
-      - S1557611102.061591,VS0,VE521
+      - S1573575024.240097,VS0,VE283
     status: 200 OK
     code: 200
+    duration: ""

--- a/fastly/fixtures/wafs/version.yaml
+++ b/fastly/fixtures/wafs/version.yaml
@@ -1,23 +1,20 @@
 ---
 version: 1
-rwmutex: {}
 interactions:
 - request:
-    body: Service=7i6HN3TK9wS159v2gPAZ8A
+    body: Service=6gkEdARZ3mPzhQvdi2YH3j
     form:
       Service:
-      - 7i6HN3TK9wS159v2gPAZ8A
+      - 6gkEdARZ3mPzhQvdi2YH3j
     headers:
       Content-Type:
       - application/x-www-form-urlencoded
-      Fastly-Key:
-      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
-      - FastlyGo/0.4.3.dev (+github.com/fastly/go-fastly; go1.12)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version
+      - FastlyGo/1.3.0 (+github.com/fastly/go-fastly; go1.13.4)
+    url: https://api.fastly.com/service/6gkEdARZ3mPzhQvdi2YH3j/version
     method: POST
   response:
-    body: '{"service_id":"7i6HN3TK9wS159v2gPAZ8A","number":54}'
+    body: '{"service_id":"6gkEdARZ3mPzhQvdi2YH3j","number":2}'
     headers:
       Accept-Ranges:
       - bytes
@@ -26,11 +23,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sat, 11 May 2019 21:44:58 GMT
+      - Tue, 12 Nov 2019 16:10:21 GMT
       Fastly-Ratelimit-Remaining:
-      - "992"
+      - "976"
       Fastly-Ratelimit-Reset:
-      - "1557612000"
+      - "1573578000"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -39,14 +36,14 @@ interactions:
       - Accept-Encoding
       Via:
       - 1.1 varnish
-      - 1.1 varnish
       X-Cache:
       - MISS, MISS
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9037-CONTROL-SLWDC, cache-lax8631-LAX
+      - cache-control-slwdc9037-CONTROL-SLWDC, cache-lcy19279-LCY
       X-Timer:
-      - S1557611098.123270,VS0,VE502
+      - S1573575021.764746,VS0,VE374
     status: 200 OK
     code: 200
+    duration: ""

--- a/fastly/waf.go
+++ b/fastly/waf.go
@@ -22,13 +22,27 @@ type WAFConfigurationSet struct {
 
 // WAF is the information about a firewall object.
 type WAF struct {
-	ID                string     `jsonapi:"primary,waf"`
-	Version           int        `jsonapi:"attr,version"`
-	PrefetchCondition string     `jsonapi:"attr,prefetch_condition"`
-	Response          string     `jsonapi:"attr,response"`
-	LastPush          *time.Time `jsonapi:"attr,last_push,iso8601"`
+	ID                             string     `jsonapi:"primary,waf_firewall"`
+	ServiceID                      string     `jsonapi:"attr,service_id"`
+	ServiceVersion                 int        `jsonapi:"attr,service_version_number"`
+	PrefetchCondition              string     `jsonapi:"attr,prefetch_condition"`
+	Response                       string     `jsonapi:"attr,response"`
+	Disabled                       bool       `jsonapi:"attr,disabled"`
+	CreatedAt                      *time.Time `jsonapi:"attr,created_at,iso8601"`
+	UpdatedAt                      *time.Time `jsonapi:"attr,updated_at,iso8601"`
+	ActiveRulesTrustwaveLogCount   int        `jsonapi:"attr,active_rules_trustwave_log_count"`
+	ActiveRulesTrustwaveBlockCount int        `jsonapi:"attr,active_rules_trustwave_block_count"`
+	ActiveRulesFastlyLogCount      int        `jsonapi:"attr,active_rules_fastly_log_count"`
+	ActiveRulesFastlyBlockCount    int        `jsonapi:"attr,active_rules_fastly_block_count"`
+	ActiveRulesOWASPLogCount       int        `jsonapi:"attr,active_rules_owasp_log_count"`
+	ActiveRulesOWASPBlockCount     int        `jsonapi:"attr,active_rules_owasp_block_count"`
+	ActiveRulesOWASPScoreCount     int        `jsonapi:"attr,active_rules_owasp_score_count"`
+}
 
-	ConfigurationSet *WAFConfigurationSet `jsonapi:"relation,configuration_set"`
+// WAFResponse th eobject containing the list of waf results
+type WAFResponse struct {
+	Items []*WAF
+	Info  infoResponse
 }
 
 // wafType is used for reflection because JSONAPI wants to know what it's
@@ -37,30 +51,58 @@ var wafType = reflect.TypeOf(new(WAF))
 
 // ListWAFsInput is used as input to the ListWAFs function.
 type ListWAFsInput struct {
-	// Service is the ID of the service (required).
-	Service string
+	// Limit the number of returned firewalls.
+	PageSize int
+	// Request a specific page of firewalls.
+	PageNumber int
+	// Specify the service ID of the returned firewalls.
+	FilterService string
+	// Specify the version of the service for the firewalls.
+	FilterVersion int
+	// Include relationships. Optional, comma-separated values. Permitted values: waf_firewall_versions.
+	Include string
+}
 
-	// Version is the specific configuration version (required).
-	Version int
+func (i *ListWAFsInput) formatFilters() map[string]string {
+
+	result := map[string]string{}
+	pairings := map[string]interface{}{
+		"page[size]":                     i.PageSize,
+		"page[number]":                   i.PageNumber,
+		"filter[service_id]":             i.FilterService,
+		"filter[service_version_number]": i.FilterVersion,
+		"include":                        i.Include,
+	}
+
+	for key, value := range pairings {
+		switch t := reflect.TypeOf(value).String(); t {
+		case "string":
+			if value != "" {
+				result[key] = value.(string)
+			}
+		case "int":
+			if value != 0 {
+				result[key] = strconv.Itoa(value.(int))
+			}
+		}
+	}
+	return result
 }
 
 // ListWAFs returns the list of wafs for the configuration version.
-func (c *Client) ListWAFs(i *ListWAFsInput) ([]*WAF, error) {
-	if i.Service == "" {
-		return nil, ErrMissingService
-	}
+func (c *Client) ListWAFs(i *ListWAFsInput) (*WAFResponse, error) {
 
-	if i.Version == 0 {
-		return nil, ErrMissingVersion
-	}
-
-	path := fmt.Sprintf("/service/%s/version/%d/wafs", i.Service, i.Version)
-	resp, err := c.Get(path, nil)
+	resp, err := c.Get("/waf/firewalls", &RequestOptions{
+		Params: i.formatFilters(),
+	})
 	if err != nil {
 		return nil, err
 	}
-
-	data, err := jsonapi.UnmarshalManyPayload(resp.Body, wafType)
+	info, body, err := getInfo(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	data, err := jsonapi.UnmarshalManyPayload(body, wafType)
 	if err != nil {
 		return nil, err
 	}
@@ -73,19 +115,22 @@ func (c *Client) ListWAFs(i *ListWAFsInput) ([]*WAF, error) {
 		}
 		wafs[i] = typed
 	}
-	return wafs, nil
+
+	return &WAFResponse{
+		Items: wafs,
+		Info:  info,
+	}, nil
 }
 
 // CreateWAFInput is used as input to the CreateWAF function.
 type CreateWAFInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
-	Service string
-	Version int
-
-	ID                string `jsonapi:"primary,waf"`
-	PrefetchCondition string `jsonapi:"attr,prefetch_condition,omitempty"`
-	Response          string `jsonapi:"attr,response,omitempty"`
+	ID                string `jsonapi:"primary,waf_firewall"`
+	Service           string `jsonapi:"attr,service_id"`
+	Version           string `jsonapi:"attr,service_version_number"`
+	PrefetchCondition string `jsonapi:"attr,prefetch_condition"`
+	Response          string `jsonapi:"attr,response"`
 }
 
 // CreateWAF creates a new Fastly WAF.
@@ -94,11 +139,11 @@ func (c *Client) CreateWAF(i *CreateWAFInput) (*WAF, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == 0 {
+	if i.Version == "" {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/wafs", i.Service, i.Version)
+	path := "/waf/firewalls"
 	resp, err := c.PostJSONAPI(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -116,18 +161,18 @@ type GetWAFInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version int
-
+	Version string
 	// ID is the id of the WAF to get.
 	ID string
 }
 
+// GetWAF gets details for given WAF
 func (c *Client) GetWAF(i *GetWAFInput) (*WAF, error) {
 	if i.Service == "" {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == 0 {
+	if i.Version == "" {
 		return nil, ErrMissingVersion
 	}
 
@@ -135,8 +180,12 @@ func (c *Client) GetWAF(i *GetWAFInput) (*WAF, error) {
 		return nil, ErrMissingWAFID
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/wafs/%s", i.Service, i.Version, i.ID)
-	resp, err := c.Get(path, nil)
+	path := fmt.Sprintf("/waf/firewalls/%s", i.ID)
+	resp, err := c.Get(path, &RequestOptions{
+		Params: map[string]string{
+			"filter[service_version_number]": i.Version,
+		},
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -152,12 +201,11 @@ func (c *Client) GetWAF(i *GetWAFInput) (*WAF, error) {
 type UpdateWAFInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
-	Service string
-	Version int
-
-	ID                string `jsonapi:"primary,waf"`
-	PrefetchCondition string `jsonapi:"attr,prefetch_condition,omitempty"`
-	Response          string `jsonapi:"attr,response,omitempty"`
+	ID                string `jsonapi:"primary,waf_firewall"`
+	Service           string `jsonapi:"attr,service_id"`
+	Version           string `jsonapi:"attr,service_version_number"`
+	PrefetchCondition string `jsonapi:"attr,prefetch_condition"`
+	Response          string `jsonapi:"attr,response"`
 }
 
 // UpdateWAF updates a specific WAF.
@@ -166,7 +214,7 @@ func (c *Client) UpdateWAF(i *UpdateWAFInput) (*WAF, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == 0 {
+	if i.Version == "" {
 		return nil, ErrMissingVersion
 	}
 
@@ -174,7 +222,7 @@ func (c *Client) UpdateWAF(i *UpdateWAFInput) (*WAF, error) {
 		return nil, ErrMissingWAFID
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/wafs/%s", i.Service, i.Version, i.ID)
+	path := fmt.Sprintf("/waf/firewalls/%s", i.ID)
 	resp, err := c.PatchJSONAPI(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -187,23 +235,84 @@ func (c *Client) UpdateWAF(i *UpdateWAFInput) (*WAF, error) {
 	return &waf, nil
 }
 
-// DeleteWAFInput is used as input to the DeleteWAFInput function.
-type DeleteWAFInput struct {
-	// Service is the ID of the service. Version is the specific configuration
-	// version. Both fields are required.
-	Service string
-	Version int
+// EnableWAF updates a specific WAF.
+func (c *Client) EnableWAF(id string) error {
 
-	// ID is the id of the WAF to delete.
-	ID string
+	if id == "" {
+		return ErrMissingWAFID
+	}
+
+	path := fmt.Sprintf("/waf/firewalls/%s/enable", id)
+	resp, err := c.PatchJSONAPI(path, &UpdateWAFInput{}, nil)
+	if err != nil {
+		return err
+	}
+
+	var waf WAF
+	if err := jsonapi.UnmarshalPayload(resp.Body, &waf); err != nil {
+		return err
+	}
+	return nil
 }
 
-func (c *Client) DeleteWAF(i *DeleteWAFInput) error {
-	if i.Service == "" {
-		return ErrMissingService
+// DisableWAF disables a WAF
+func (c *Client) DisableWAF(id string) error {
+
+	if id == "" {
+		return ErrMissingWAFID
+	}
+
+	path := fmt.Sprintf("/waf/firewalls/%s/disable", id)
+	resp, err := c.PatchJSONAPI(path, &UpdateWAFInput{}, nil)
+	if err != nil {
+		return err
+	}
+
+	var waf WAF
+	if err := jsonapi.UnmarshalPayload(resp.Body, &waf); err != nil {
+		return err
+	}
+	return nil
+}
+
+// DeployWAFInput used to deploy a WAF
+type DeployWAFInput struct {
+	// These are the Id and version of the WAF
+	ID      string
+	Version int
+}
+
+// DeployWAFVersion deploys (activate) a WAF
+func (c *Client) DeployWAFVersion(i *DeployWAFInput) error {
+
+	if i.ID == "" {
+		return ErrMissingWAFID
 	}
 
 	if i.Version == 0 {
+		return ErrMissingVersion
+	}
+
+	path := fmt.Sprintf("/waf/firewalls/%s/versions/%d", i.ID, i.Version)
+	_, err := c.PostJSONAPI(path, i, nil)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// DeleteWAFInput is used as input to the DeleteWAFInput function.
+type DeleteWAFInput struct {
+	// this is the WAF id
+	ID string `jsonapi:"primary,waf_firewall"`
+	// The service version
+	Version string `jsonapi:"attr,service_version_number"`
+}
+
+// DeleteWAF deletes a given WAF from its service
+func (c *Client) DeleteWAF(i *DeleteWAFInput) error {
+
+	if i.Version == "" {
 		return ErrMissingVersion
 	}
 
@@ -211,8 +320,8 @@ func (c *Client) DeleteWAF(i *DeleteWAFInput) error {
 		return ErrMissingWAFID
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/wafs/%s", i.Service, i.Version, i.ID)
-	_, err := c.Delete(path, nil)
+	path := fmt.Sprintf("/waf/firewalls/%s", i.ID)
+	_, err := c.DeleteJSON(path, i, nil)
 	return err
 }
 
@@ -721,6 +830,12 @@ type linksResponse struct {
 	Links paginationInfo `json:"links"`
 }
 
+// infoResponse used to pull the links and meta from the result
+type infoResponse struct {
+	Links paginationInfo `json:"links"`
+	Meta  metaInfo       `json:"meta"`
+}
+
 // paginationInfo stores links to searches related to the current one, showing
 // any information about additional results being stored on another page
 type paginationInfo struct {
@@ -732,6 +847,14 @@ type paginationInfo struct {
 // GetWAFRuleStatusesResponse is the data returned to the user from a GetWAFRuleStatus call
 type GetWAFRuleStatusesResponse struct {
 	Rules []*WAFRuleStatus
+}
+
+// metaInfo stores information about the result returned by the server
+type metaInfo struct {
+	CurrentPage int `json:"current_page,omitempty"`
+	PerPage     int `json:"per_page,omitempty"`
+	RecordCount int `json:"record_count,omitempty"`
+	TotalPages  int `json:"total_pages,omitempty"`
 }
 
 // getPages parses a response to get the pagination data without destroying
@@ -749,6 +872,22 @@ func getPages(body io.Reader) (paginationInfo, io.Reader, error) {
 	var pages linksResponse
 	json.Unmarshal(bodyBytes, &pages)
 	return pages.Links, bytes.NewReader(buf.Bytes()), nil
+}
+
+func getInfo(body io.Reader) (infoResponse, io.Reader, error) {
+	var buf bytes.Buffer
+	tee := io.TeeReader(body, &buf)
+
+	bodyBytes, err := ioutil.ReadAll(tee)
+	if err != nil {
+		return infoResponse{}, nil, err
+	}
+
+	var info infoResponse
+	if err := json.Unmarshal(bodyBytes, &info); err != nil {
+		return infoResponse{}, nil, err
+	}
+	return info, bytes.NewReader(buf.Bytes()), nil
 }
 
 // GetWAFRuleStatusInput specifies the parameters for the GetWAFRuleStatus call.

--- a/fastly/waf.go
+++ b/fastly/waf.go
@@ -39,7 +39,7 @@ type WAF struct {
 	ActiveRulesOWASPScoreCount     int        `jsonapi:"attr,active_rules_owasp_score_count"`
 }
 
-// WAFResponse th eobject containing the list of waf results
+// WAFResponse an object containing the list of WAF results.
 type WAFResponse struct {
 	Items []*WAF
 	Info  infoResponse

--- a/fastly/waf.go
+++ b/fastly/waf.go
@@ -878,6 +878,7 @@ func getPages(body io.Reader) (paginationInfo, io.Reader, error) {
 	return pages.Links, bytes.NewReader(buf.Bytes()), nil
 }
 
+// getResponseInfo parses a response to get the pagination and metadata info.
 func getResponseInfo(body io.Reader) (infoResponse, error) {
 
 	bodyBytes, err := ioutil.ReadAll(body)

--- a/fastly/waf.go
+++ b/fastly/waf.go
@@ -849,7 +849,7 @@ type GetWAFRuleStatusesResponse struct {
 	Rules []*WAFRuleStatus
 }
 
-// metaInfo stores information about the result returned by the server
+// metaInfo stores information about the result returned by the server.
 type metaInfo struct {
 	CurrentPage int `json:"current_page,omitempty"`
 	PerPage     int `json:"per_page,omitempty"`

--- a/fastly/waf.go
+++ b/fastly/waf.go
@@ -830,7 +830,7 @@ type linksResponse struct {
 	Links paginationInfo `json:"links"`
 }
 
-// infoResponse used to pull the links and meta from the result
+// infoResponse is used to pull the links and meta from the result.
 type infoResponse struct {
 	Links paginationInfo `json:"links"`
 	Meta  metaInfo       `json:"meta"`

--- a/fastly/waf.go
+++ b/fastly/waf.go
@@ -275,7 +275,7 @@ func (c *Client) DisableWAF(id string) error {
 	return nil
 }
 
-// DeployWAFInput used to deploy a WAF
+// DeployWAFInput is the input configuration used to deploy a WAF.
 type DeployWAFInput struct {
 	// These are the Id and version of the WAF
 	ID      string

--- a/fastly/waf.go
+++ b/fastly/waf.go
@@ -307,7 +307,7 @@ func (c *Client) DeployWAFVersion(i *DeployWAFInput) error {
 
 // DeleteWAFInput is used as input to the DeleteWAFInput function.
 type DeleteWAFInput struct {
-	// this is the WAF id
+	// This is the WAF ID.
 	ID string `jsonapi:"primary,waf_firewall"`
 	// The service version.
 	Version string `jsonapi:"attr,service_version_number"`

--- a/fastly/waf.go
+++ b/fastly/waf.go
@@ -277,7 +277,7 @@ func (c *Client) DisableWAF(id string) error {
 
 // DeployWAFInput is the input configuration used to deploy a WAF.
 type DeployWAFInput struct {
-	// These are the Id and version of the WAF
+	// These are the ID and version of the WAF.
 	ID      string
 	Version int
 }

--- a/fastly/waf.go
+++ b/fastly/waf.go
@@ -305,7 +305,7 @@ func (c *Client) DeployWAFVersion(i *DeployWAFInput) error {
 type DeleteWAFInput struct {
 	// this is the WAF id
 	ID string `jsonapi:"primary,waf_firewall"`
-	// The service version
+	// The service version.
 	Version string `jsonapi:"attr,service_version_number"`
 }
 

--- a/fastly/waf.go
+++ b/fastly/waf.go
@@ -282,7 +282,7 @@ type DeployWAFInput struct {
 	Version int
 }
 
-// DeployWAFVersion deploys (activate) a WAF
+// DeployWAFVersion deploys (i.e. activates) a WAF by version.
 func (c *Client) DeployWAFVersion(i *DeployWAFInput) error {
 
 	if i.ID == "" {

--- a/fastly/waf.go
+++ b/fastly/waf.go
@@ -309,7 +309,7 @@ type DeleteWAFInput struct {
 	Version string `jsonapi:"attr,service_version_number"`
 }
 
-// DeleteWAF deletes a given WAF from its service
+// DeleteWAF deletes a given WAF from its service.
 func (c *Client) DeleteWAF(i *DeleteWAFInput) error {
 
 	if i.Version == "" {

--- a/fastly/waf.go
+++ b/fastly/waf.go
@@ -255,7 +255,7 @@ func (c *Client) EnableWAF(id string) error {
 	return nil
 }
 
-// DisableWAF disables a WAF
+// DisableWAF disables a WAF.
 func (c *Client) DisableWAF(id string) error {
 
 	if id == "" {

--- a/fastly/waf_test.go
+++ b/fastly/waf_test.go
@@ -3,23 +3,27 @@ package fastly
 import (
 	"bytes"
 	"io/ioutil"
+	"reflect"
+	"strconv"
 	"testing"
 )
 
 func TestClient_WAFs(t *testing.T) {
 	t.Parallel()
 
-	var err error
-	var tv *Version
-	record(t, "wafs/version", func(c *Client) {
-		tv = testVersion(t, c)
-	})
+	fixtureBase := "wafs/"
 
+	testService := createTestService(t, fixtureBase+"create_service", "service")
+	defer deleteTestService(t, fixtureBase+"delete_service", testService.ID)
+
+	tv := createTestVersion(t, fixtureBase+"/version", testService.ID)
+
+	var err error
 	// Enable logging on the service - we cannot create wafs without logging
 	// enabled
-	record(t, "wafs/logging/create", func(c *Client) {
+	record(t, fixtureBase+"/logging/create", func(c *Client) {
 		_, err = c.CreateSyslog(&CreateSyslogInput{
-			Service:       testServiceID,
+			Service:       testService.ID,
 			Version:       tv.Number,
 			Name:          "test-syslog",
 			Address:       "example.com",
@@ -35,9 +39,9 @@ func TestClient_WAFs(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer func() {
-		record(t, "wafs/logging/cleanup", func(c *Client) {
+		record(t, fixtureBase+"/logging/cleanup", func(c *Client) {
 			c.DeleteSyslog(&DeleteSyslogInput{
-				Service: testServiceID,
+				Service: testService.ID,
 				Version: tv.Number,
 				Name:    "test-syslog",
 			})
@@ -46,11 +50,11 @@ func TestClient_WAFs(t *testing.T) {
 
 	// Create a condition - we cannot create a waf without attaching a condition
 	var condition *Condition
-	record(t, "wafs/condition/create", func(c *Client) {
+	record(t, fixtureBase+"/condition/create", func(c *Client) {
 		condition, err = c.CreateCondition(&CreateConditionInput{
-			Service:   testServiceID,
+			Service:   testService.ID,
 			Version:   tv.Number,
-			Name:      "test-waf-condition",
+			Name:      "WAF_Prefetch",
 			Statement: "req.url~+\"index.html\"",
 			Type:      "PREFETCH", // This must be a prefetch condition
 			Priority:  1,
@@ -60,22 +64,22 @@ func TestClient_WAFs(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer func() {
-		record(t, "wafs/condition/cleanup", func(c *Client) {
+		record(t, fixtureBase+"/condition/cleanup", func(c *Client) {
 			c.DeleteCondition(&DeleteConditionInput{
-				Service: testServiceID,
+				Service: testService.ID,
 				Version: tv.Number,
-				Name:    "test-waf-condition",
+				Name:    condition.Name,
 			})
 		})
 	}()
 
 	// Create a response object
 	var ro *ResponseObject
-	record(t, "wafs/response_object/create", func(c *Client) {
+	record(t, fixtureBase+"/response_object/create", func(c *Client) {
 		ro, err = c.CreateResponseObject(&CreateResponseObjectInput{
-			Service:     testServiceID,
+			Service:     testService.ID,
 			Version:     tv.Number,
-			Name:        "test-response-object",
+			Name:        "WAf_Response",
 			Status:      200,
 			Response:    "Ok",
 			Content:     "abcd",
@@ -86,9 +90,9 @@ func TestClient_WAFs(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer func() {
-		record(t, "wafs/response_object/cleanup", func(c *Client) {
+		record(t, fixtureBase+"/response_object/cleanup", func(c *Client) {
 			c.DeleteResponseObject(&DeleteResponseObjectInput{
-				Service: testServiceID,
+				Service: testService.ID,
 				Version: tv.Number,
 				Name:    ro.Name,
 			})
@@ -97,10 +101,10 @@ func TestClient_WAFs(t *testing.T) {
 
 	// Create
 	var waf *WAF
-	record(t, "wafs/create", func(c *Client) {
+	record(t, fixtureBase+"/create", func(c *Client) {
 		waf, err = c.CreateWAF(&CreateWAFInput{
-			Service:           testServiceID,
-			Version:           tv.Number,
+			Service:           testService.ID,
+			Version:           strconv.Itoa(tv.Number),
 			PrefetchCondition: condition.Name,
 			Response:          ro.Name,
 		})
@@ -110,26 +114,25 @@ func TestClient_WAFs(t *testing.T) {
 	}
 
 	// List
-	var wafs []*WAF
-	record(t, "wafs/list", func(c *Client) {
-		wafs, err = c.ListWAFs(&ListWAFsInput{
-			Service: testServiceID,
-			Version: tv.Number,
+	var wafsResp *WAFResponse
+	record(t, fixtureBase+"/list", func(c *Client) {
+		wafsResp, err = c.ListWAFs(&ListWAFsInput{
+			FilterService: testService.ID,
+			FilterVersion: tv.Number,
 		})
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(wafs) < 1 {
-		t.Errorf("bad wafs: %v", wafs)
+	if len(wafsResp.Items) < 0 {
+		t.Errorf("bad wafs: %v", wafsResp.Items)
 	}
 
 	// Ensure deleted
 	defer func() {
-		record(t, "wafs/cleanup", func(c *Client) {
+		record(t, fixtureBase+"/cleanup", func(c *Client) {
 			c.DeleteWAF(&DeleteWAFInput{
-				Service: testServiceID,
-				Version: tv.Number,
+				Version: strconv.Itoa(tv.Number),
 				ID:      waf.ID,
 			})
 		})
@@ -137,10 +140,10 @@ func TestClient_WAFs(t *testing.T) {
 
 	// Get
 	var nwaf *WAF
-	record(t, "wafs/get", func(c *Client) {
+	record(t, fixtureBase+"/get", func(c *Client) {
 		nwaf, err = c.GetWAF(&GetWAFInput{
-			Service: testServiceID,
-			Version: tv.Number,
+			Service: testService.ID,
+			Version: strconv.Itoa(tv.Number),
 			ID:      waf.ID,
 		})
 	})
@@ -154,9 +157,9 @@ func TestClient_WAFs(t *testing.T) {
 	// Update
 	// Create a new response object to attach
 	var nro *ResponseObject
-	record(t, "wafs/response_object/create_another", func(c *Client) {
+	record(t, fixtureBase+"/response_object/create_another", func(c *Client) {
 		nro, err = c.CreateResponseObject(&CreateResponseObjectInput{
-			Service:     testServiceID,
+			Service:     testService.ID,
 			Version:     tv.Number,
 			Name:        "test-response-object-2",
 			Status:      200,
@@ -169,19 +172,19 @@ func TestClient_WAFs(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer func() {
-		record(t, "wafs/response_object/cleanup_another", func(c *Client) {
+		record(t, fixtureBase+"/response_object/cleanup_another", func(c *Client) {
 			c.DeleteResponseObject(&DeleteResponseObjectInput{
-				Service: testServiceID,
+				Service: testService.ID,
 				Version: tv.Number,
 				Name:    nro.Name,
 			})
 		})
 	}()
 	var uwaf *WAF
-	record(t, "wafs/update", func(c *Client) {
+	record(t, fixtureBase+"/update", func(c *Client) {
 		uwaf, err = c.UpdateWAF(&UpdateWAFInput{
-			Service:  testServiceID,
-			Version:  tv.Number,
+			Service:  testService.ID,
+			Version:  strconv.Itoa(tv.Number),
 			ID:       waf.ID,
 			Response: nro.Name,
 		})
@@ -194,10 +197,9 @@ func TestClient_WAFs(t *testing.T) {
 	}
 
 	// Delete
-	record(t, "wafs/delete", func(c *Client) {
+	record(t, fixtureBase+"/delete", func(c *Client) {
 		err = c.DeleteWAF(&DeleteWAFInput{
-			Service: testServiceID,
-			Version: tv.Number,
+			Version: strconv.Itoa(tv.Number),
 			ID:      waf.ID,
 		})
 	})
@@ -205,24 +207,6 @@ func TestClient_WAFs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-}
-
-func TestClient_ListWAFs_validation(t *testing.T) {
-	var err error
-	_, err = testClient.ListWAFs(&ListWAFsInput{
-		Service: "",
-	})
-	if err != ErrMissingService {
-		t.Errorf("bad error: %s", err)
-	}
-
-	_, err = testClient.ListWAFs(&ListWAFsInput{
-		Service: "foo",
-		Version: 0,
-	})
-	if err != ErrMissingVersion {
-		t.Errorf("bad error: %s", err)
-	}
 }
 
 func TestClient_CreateWAF_validation(t *testing.T) {
@@ -236,7 +220,7 @@ func TestClient_CreateWAF_validation(t *testing.T) {
 
 	_, err = testClient.CreateWAF(&CreateWAFInput{
 		Service: "foo",
-		Version: 0,
+		Version: "",
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -254,7 +238,7 @@ func TestClient_GetWAF_validation(t *testing.T) {
 
 	_, err = testClient.GetWAF(&GetWAFInput{
 		Service: "foo",
-		Version: 0,
+		Version: "",
 	})
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
@@ -262,7 +246,33 @@ func TestClient_GetWAF_validation(t *testing.T) {
 
 	_, err = testClient.GetWAF(&GetWAFInput{
 		Service: "foo",
-		Version: 1,
+		Version: "1",
+	})
+	if err != ErrMissingWAFID {
+		t.Errorf("bad error: %s", err)
+	}
+}
+
+func TestClient_UpdateWAF_validation(t *testing.T) {
+	var err error
+	_, err = testClient.UpdateWAF(&UpdateWAFInput{
+		Service: "",
+	})
+	if err != ErrMissingService {
+		t.Errorf("bad error: %s", err)
+	}
+
+	_, err = testClient.UpdateWAF(&UpdateWAFInput{
+		Service: "foo",
+		Version: "",
+	})
+	if err != ErrMissingVersion {
+		t.Errorf("bad error: %s", err)
+	}
+
+	_, err = testClient.UpdateWAF(&UpdateWAFInput{
+		Service: "foo",
+		Version: "1",
 		ID:      "",
 	})
 	if err != ErrMissingWAFID {
@@ -270,60 +280,63 @@ func TestClient_GetWAF_validation(t *testing.T) {
 	}
 }
 
-//
-// func TestClient_UpdateWAF_validation(t *testing.T) {
-// 	var err error
-// 	_, err = testClient.UpdateWAF(&UpdateWAFInput{
-// 		Service: "",
-// 	})
-// 	if err != ErrMissingService {
-// 		t.Errorf("bad error: %s", err)
-// 	}
-//
-// 	_, err = testClient.UpdateWAF(&UpdateWAFInput{
-// 		Service: "foo",
-// 		Version: 0,
-// 	})
-// 	if err != ErrMissingVersion {
-// 		t.Errorf("bad error: %s", err)
-// 	}
-//
-// 	_, err = testClient.UpdateWAF(&UpdateWAFInput{
-// 		Service: "foo",
-// 		Version: 1,
-// 		WAFID:   "",
-// 	})
-// 	if err != ErrMissingWAFID {
-// 		t.Errorf("bad error: %s", err)
-// 	}
-// }
-//
-// func TestClient_DeleteWAF_validation(t *testing.T) {
-// 	var err error
-// 	err = testClient.DeleteWAF(&DeleteWAFInput{
-// 		Service: "",
-// 	})
-// 	if err != ErrMissingService {
-// 		t.Errorf("bad error: %s", err)
-// 	}
-//
-// 	err = testClient.DeleteWAF(&DeleteWAFInput{
-// 		Service: "foo",
-// 		Version: 0,
-// 	})
-// 	if err != ErrMissingVersion {
-// 		t.Errorf("bad error: %s", err)
-// 	}
-//
-// 	err = testClient.DeleteWAF(&DeleteWAFInput{
-// 		Service: "foo",
-// 		Version: 1,
-// 		WAFID:   "",
-// 	})
-// 	if err != ErrMissingWAFID {
-// 		t.Errorf("bad error: %s", err)
-// 	}
-// }
+func TestClient_DeleteWAF_validation(t *testing.T) {
+	var err error
+	err = testClient.DeleteWAF(&DeleteWAFInput{
+		Version: "",
+	})
+	if err != ErrMissingVersion {
+		t.Errorf("bad error: %s", err)
+	}
+
+	err = testClient.DeleteWAF(&DeleteWAFInput{
+		Version: "1",
+		ID:      "",
+	})
+	if err != ErrMissingWAFID {
+		t.Errorf("bad error: %s", err)
+	}
+}
+
+func TestClient_listWAFs_formatFilters(t *testing.T) {
+	cases := []struct {
+		remote *ListWAFsInput
+		local  map[string]string
+	}{
+		{
+			remote: &ListWAFsInput{
+				FilterService: "service1",
+				FilterVersion: 1,
+			},
+			local: map[string]string{
+				"filter[service_id]":             "service1",
+				"filter[service_version_number]": "1",
+			},
+		},
+		{
+			remote: &ListWAFsInput{
+				FilterService: "service1",
+				FilterVersion: 1,
+				PageSize:      2,
+				PageNumber:    2,
+				Include:       "included",
+			},
+			local: map[string]string{
+				"filter[service_id]":             "service1",
+				"filter[service_version_number]": "1",
+				"page[size]":                     "2",
+				"page[number]":                   "2",
+				"include":                        "included",
+			},
+		},
+	}
+	for _, c := range cases {
+		out := c.remote.formatFilters()
+		if !reflect.DeepEqual(out, c.local) {
+			t.Fatalf("Error matching:\nexpected: %#v\n     got: %#v", c.local, out)
+		}
+	}
+}
 
 func TestUpdateWAFRuleStatusesInput_validate(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
This PR contains the implementation of the service's waf component endpoints for the new API. Note that only endpoints related to the service waf block have been implemented, leaving the rest of the code using the old API, with the exception of enabling/disabling waf which has been created but no test coverage yet. Test coverage for enabling/disabling waf will be addressed within the waf configuration resource scope.