### PR TITLE
Add LastDeploymentStatus so clients can deal with async deploys

### DIFF
--- a/fastly/fixtures/waf_versions/clone.yaml
+++ b/fastly/fixtures/waf_versions/clone.yaml
@@ -12,17 +12,17 @@ interactions:
       - application/vnd.api+json
       User-Agent:
       - FastlyGo/1.16.0 (+github.com/fastly/go-fastly; go1.14.2)
-    url: https://api.fastly.com/waf/firewalls/5oX1X8cVEBpEXg6PsNSTXA/versions/1/clone
+    url: https://api.fastly.com/waf/firewalls/7kRiB97L3ppEaKv5J3hJmV/versions/1/clone
     method: PUT
   response:
-    body: '{"data":{"id":"6q3TBLBKV00lMIsp0DC3wq","type":"waf_firewall_version","attributes":{"active":false,"active_rules_fastly_block_count":0,"active_rules_fastly_log_count":0,"active_rules_owasp_block_count":0,"active_rules_owasp_log_count":0,"active_rules_owasp_score_count":0,"active_rules_trustwave_block_count":0,"active_rules_trustwave_log_count":0,"allowed_http_versions":"HTTP/1.0
-      HTTP/1.1 HTTP/2","allowed_methods":"GET HEAD POST OPTIONS PUT PATCH DELETE","allowed_request_content_type":"application/x-www-form-urlencoded|multipart/form-data|text/xml|application/xml|application/soap+xml|application/x-amf|application/json|application/octet-stream|application/csp-report|application/xss-auditor-report|text/plain","allowed_request_content_type_charset":"utf-8|iso-8859-1|iso-8859-15|windows-1252","arg_name_length":100,"arg_length":400,"combined_file_sizes":10000000,"comment":null,"created_at":"2020-07-02T20:20:58Z","critical_anomaly_score":5,"crs_validate_utf8_encoding":false,"deployed_at":null,"error":null,"error_anomaly_score":4,"high_risk_country_codes":"","http_violation_score_threshold":999,"inbound_anomaly_score_threshold":999,"last_deployment_status":null,"lfi_score_threshold":999,"locked":false,"max_file_size":10000000,"max_num_args":255,"notice_anomaly_score":2,"number":2,"paranoia_level":1,"php_injection_score_threshold":999,"rce_score_threshold":999,"restricted_extensions":".asa/
+    body: '{"data":{"id":"6BowSDK5ezUJMnkXOUWVuD","type":"waf_firewall_version","attributes":{"active":false,"active_rules_fastly_block_count":0,"active_rules_fastly_log_count":0,"active_rules_owasp_block_count":0,"active_rules_owasp_log_count":0,"active_rules_owasp_score_count":0,"active_rules_trustwave_block_count":0,"active_rules_trustwave_log_count":0,"allowed_http_versions":"HTTP/1.0
+      HTTP/1.1 HTTP/2","allowed_methods":"GET HEAD POST OPTIONS PUT PATCH DELETE","allowed_request_content_type":"application/x-www-form-urlencoded|multipart/form-data|text/xml|application/xml|application/soap+xml|application/x-amf|application/json|application/octet-stream|application/csp-report|application/xss-auditor-report|text/plain","allowed_request_content_type_charset":"utf-8|iso-8859-1|iso-8859-15|windows-1252","arg_name_length":100,"arg_length":400,"combined_file_sizes":10000000,"comment":null,"created_at":"2020-07-06T11:09:09Z","critical_anomaly_score":5,"crs_validate_utf8_encoding":false,"deployed_at":null,"error":null,"error_anomaly_score":4,"high_risk_country_codes":"","http_violation_score_threshold":999,"inbound_anomaly_score_threshold":999,"last_deployment_status":null,"lfi_score_threshold":999,"locked":false,"max_file_size":10000000,"max_num_args":255,"notice_anomaly_score":2,"number":2,"paranoia_level":1,"php_injection_score_threshold":999,"rce_score_threshold":999,"restricted_extensions":".asa/
       .asax/ .ascx/ .axd/ .backup/ .bak/ .bat/ .cdx/ .cer/ .cfg/ .cmd/ .com/ .config/
       .conf/ .cs/ .csproj/ .csr/ .dat/ .db/ .dbf/ .dll/ .dos/ .htr/ .htw/ .ida/ .idc/
       .idq/ .inc/ .ini/ .key/ .licx/ .lnk/ .log/ .mdb/ .old/ .pass/ .pdb/ .pol/ .printer/
       .pwd/ .resources/ .resx/ .sql/ .sys/ .vb/ .vbs/ .vbproj/ .vsdisco/ .webinfo/
       .xsd/ .xsx/","restricted_headers":"/proxy/ /lock-token/ /content-range/ /translate/
-      /if/","rfi_score_threshold":999,"session_fixation_score_threshold":999,"sql_injection_score_threshold":999,"total_arg_length":6400,"updated_at":"2020-07-02T20:20:58Z","warning_anomaly_score":3,"xss_score_threshold":999},"relationships":{"waf_firewall":{"data":{"id":"5oX1X8cVEBpEXg6PsNSTXA","type":"waf_firewall"}}}}}'
+      /if/","rfi_score_threshold":999,"session_fixation_score_threshold":999,"sql_injection_score_threshold":999,"total_arg_length":6400,"updated_at":"2020-07-06T11:09:09Z","warning_anomaly_score":3,"xss_score_threshold":999},"relationships":{"waf_firewall":{"data":{"id":"7kRiB97L3ppEaKv5J3hJmV","type":"waf_firewall"}}}}}'
     headers:
       Accept-Ranges:
       - bytes
@@ -32,7 +32,7 @@ interactions:
       Content-Type:
       - application/vnd.api+json
       Date:
-      - Thu, 02 Jul 2020 20:20:58 GMT
+      - Mon, 06 Jul 2020 11:09:09 GMT
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -47,9 +47,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Served-By:
-      - cache-control-slwdc9037-CONTROL-SLWDC, cache-lcy19265-LCY
+      - cache-control-slwdc9037-CONTROL-SLWDC, cache-lcy19257-LCY
       X-Timer:
-      - S1593721258.437172,VS0,VE181
+      - S1594033750.645844,VS0,VE182
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/waf_versions/condition/create.yaml
+++ b/fastly/fixtures/waf_versions/condition/create.yaml
@@ -2,10 +2,10 @@
 version: 1
 interactions:
 - request:
-    body: Service=52szbbqIWi1L5bUd4EBKkX&Version=2&name=WAF_Prefetch&priority=1&statement=req.url~%2B%22index.html%22&type=PREFETCH
+    body: Service=5GZsX83POn5zij6allCOKe&Version=2&name=WAF_Prefetch&priority=1&statement=req.url~%2B%22index.html%22&type=PREFETCH
     form:
       Service:
-      - 52szbbqIWi1L5bUd4EBKkX
+      - 5GZsX83POn5zij6allCOKe
       Version:
       - "2"
       name:
@@ -21,10 +21,10 @@ interactions:
       - application/x-www-form-urlencoded
       User-Agent:
       - FastlyGo/1.16.0 (+github.com/fastly/go-fastly; go1.14.2)
-    url: https://api.fastly.com/service/52szbbqIWi1L5bUd4EBKkX/version/2/condition
+    url: https://api.fastly.com/service/5GZsX83POn5zij6allCOKe/version/2/condition
     method: POST
   response:
-    body: '{"name":"WAF_Prefetch","priority":"1","statement":"req.url~+\"index.html\"","type":"PREFETCH","service_id":"52szbbqIWi1L5bUd4EBKkX","version":"2","created_at":"2020-07-02T20:20:56Z","updated_at":"2020-07-02T20:20:56Z","deleted_at":null,"comment":""}'
+    body: '{"name":"WAF_Prefetch","priority":"1","statement":"req.url~+\"index.html\"","type":"PREFETCH","service_id":"5GZsX83POn5zij6allCOKe","version":"2","updated_at":"2020-07-06T11:09:06Z","comment":"","deleted_at":null,"created_at":"2020-07-06T11:09:06Z"}'
     headers:
       Accept-Ranges:
       - bytes
@@ -34,11 +34,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Jul 2020 20:20:56 GMT
+      - Mon, 06 Jul 2020 11:09:06 GMT
       Fastly-Ratelimit-Remaining:
-      - "951"
+      - "978"
       Fastly-Ratelimit-Reset:
-      - "1593723600"
+      - "1594036800"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -53,9 +53,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9036-CONTROL-SLWDC, cache-lcy19265-LCY
+      - cache-control-slwdc9037-CONTROL-SLWDC, cache-lcy19257-LCY
       X-Timer:
-      - S1593721256.006684,VS0,VE198
+      - S1594033746.983994,VS0,VE199
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/waf_versions/condition/delete.yaml
+++ b/fastly/fixtures/waf_versions/condition/delete.yaml
@@ -7,7 +7,7 @@ interactions:
     headers:
       User-Agent:
       - FastlyGo/1.16.0 (+github.com/fastly/go-fastly; go1.14.2)
-    url: https://api.fastly.com/service/52szbbqIWi1L5bUd4EBKkX/version/2/condition/WAF_Prefetch
+    url: https://api.fastly.com/service/5GZsX83POn5zij6allCOKe/version/2/condition/WAF_Prefetch
     method: DELETE
   response:
     body: '{"status":"ok"}'
@@ -20,11 +20,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Jul 2020 20:21:01 GMT
+      - Mon, 06 Jul 2020 11:09:12 GMT
       Fastly-Ratelimit-Remaining:
-      - "948"
+      - "975"
       Fastly-Ratelimit-Reset:
-      - "1593723600"
+      - "1594036800"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -39,9 +39,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9037-CONTROL-SLWDC, cache-lcy19265-LCY
+      - cache-control-slwdc9036-CONTROL-SLWDC, cache-lcy19257-LCY
       X-Timer:
-      - S1593721262.721294,VS0,VE222
+      - S1594033753.708720,VS0,VE226
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/waf_versions/create_empty.yaml
+++ b/fastly/fixtures/waf_versions/create_empty.yaml
@@ -11,27 +11,27 @@ interactions:
       - application/vnd.api+json
       User-Agent:
       - FastlyGo/1.16.0 (+github.com/fastly/go-fastly; go1.14.2)
-    url: https://api.fastly.com/waf/firewalls/5oX1X8cVEBpEXg6PsNSTXA/versions
+    url: https://api.fastly.com/waf/firewalls/7kRiB97L3ppEaKv5J3hJmV/versions
     method: POST
   response:
-    body: '{"data":{"id":"7ZbqqxjPYZsBzq6nePHDRT","type":"waf_firewall_version","attributes":{"active":false,"active_rules_fastly_block_count":0,"active_rules_fastly_log_count":0,"active_rules_owasp_block_count":0,"active_rules_owasp_log_count":0,"active_rules_owasp_score_count":0,"active_rules_trustwave_block_count":0,"active_rules_trustwave_log_count":0,"allowed_http_versions":"HTTP/1.0
-      HTTP/1.1 HTTP/2","allowed_methods":"GET HEAD POST OPTIONS PUT PATCH DELETE","allowed_request_content_type":"application/x-www-form-urlencoded|multipart/form-data|text/xml|application/xml|application/soap+xml|application/x-amf|application/json|application/octet-stream|application/csp-report|application/xss-auditor-report|text/plain","allowed_request_content_type_charset":"utf-8|iso-8859-1|iso-8859-15|windows-1252","arg_name_length":100,"arg_length":400,"combined_file_sizes":10000000,"comment":null,"created_at":"2020-07-02T20:21:00Z","critical_anomaly_score":5,"crs_validate_utf8_encoding":false,"deployed_at":null,"error":null,"error_anomaly_score":4,"high_risk_country_codes":"","http_violation_score_threshold":999,"inbound_anomaly_score_threshold":999,"last_deployment_status":null,"lfi_score_threshold":999,"locked":false,"max_file_size":10000000,"max_num_args":255,"notice_anomaly_score":2,"number":3,"paranoia_level":1,"php_injection_score_threshold":999,"rce_score_threshold":999,"restricted_extensions":".asa/
+    body: '{"data":{"id":"3fLfb20XK4ep2ACbeI35T","type":"waf_firewall_version","attributes":{"active":false,"active_rules_fastly_block_count":0,"active_rules_fastly_log_count":0,"active_rules_owasp_block_count":0,"active_rules_owasp_log_count":0,"active_rules_owasp_score_count":0,"active_rules_trustwave_block_count":0,"active_rules_trustwave_log_count":0,"allowed_http_versions":"HTTP/1.0
+      HTTP/1.1 HTTP/2","allowed_methods":"GET HEAD POST OPTIONS PUT PATCH DELETE","allowed_request_content_type":"application/x-www-form-urlencoded|multipart/form-data|text/xml|application/xml|application/soap+xml|application/x-amf|application/json|application/octet-stream|application/csp-report|application/xss-auditor-report|text/plain","allowed_request_content_type_charset":"utf-8|iso-8859-1|iso-8859-15|windows-1252","arg_name_length":100,"arg_length":400,"combined_file_sizes":10000000,"comment":null,"created_at":"2020-07-06T11:09:11Z","critical_anomaly_score":5,"crs_validate_utf8_encoding":false,"deployed_at":null,"error":null,"error_anomaly_score":4,"high_risk_country_codes":"","http_violation_score_threshold":999,"inbound_anomaly_score_threshold":999,"last_deployment_status":null,"lfi_score_threshold":999,"locked":false,"max_file_size":10000000,"max_num_args":255,"notice_anomaly_score":2,"number":3,"paranoia_level":1,"php_injection_score_threshold":999,"rce_score_threshold":999,"restricted_extensions":".asa/
       .asax/ .ascx/ .axd/ .backup/ .bak/ .bat/ .cdx/ .cer/ .cfg/ .cmd/ .com/ .config/
       .conf/ .cs/ .csproj/ .csr/ .dat/ .db/ .dbf/ .dll/ .dos/ .htr/ .htw/ .ida/ .idc/
       .idq/ .inc/ .ini/ .key/ .licx/ .lnk/ .log/ .mdb/ .old/ .pass/ .pdb/ .pol/ .printer/
       .pwd/ .resources/ .resx/ .sql/ .sys/ .vb/ .vbs/ .vbproj/ .vsdisco/ .webinfo/
       .xsd/ .xsx/","restricted_headers":"/proxy/ /lock-token/ /content-range/ /translate/
-      /if/","rfi_score_threshold":999,"session_fixation_score_threshold":999,"sql_injection_score_threshold":999,"total_arg_length":6400,"updated_at":"2020-07-02T20:21:00Z","warning_anomaly_score":3,"xss_score_threshold":999},"relationships":{"waf_firewall":{"data":{"id":"5oX1X8cVEBpEXg6PsNSTXA","type":"waf_firewall"}}}}}'
+      /if/","rfi_score_threshold":999,"session_fixation_score_threshold":999,"sql_injection_score_threshold":999,"total_arg_length":6400,"updated_at":"2020-07-06T11:09:11Z","warning_anomaly_score":3,"xss_score_threshold":999},"relationships":{"waf_firewall":{"data":{"id":"7kRiB97L3ppEaKv5J3hJmV","type":"waf_firewall"}}}}}'
     headers:
       Accept-Ranges:
       - bytes
       - bytes
       Content-Length:
-      - "2126"
+      - "2125"
       Content-Type:
       - application/vnd.api+json
       Date:
-      - Thu, 02 Jul 2020 20:21:00 GMT
+      - Mon, 06 Jul 2020 11:09:11 GMT
       Status:
       - 201 Created
       Strict-Transport-Security:
@@ -46,9 +46,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Served-By:
-      - cache-control-slwdc9035-CONTROL-SLWDC, cache-lcy19265-LCY
+      - cache-control-slwdc9037-CONTROL-SLWDC, cache-lcy19257-LCY
       X-Timer:
-      - S1593721261.504568,VS0,VE189
+      - S1594033752.522295,VS0,VE172
     status: 201 Created
     code: 201
     duration: ""

--- a/fastly/fixtures/waf_versions/deploy.yaml
+++ b/fastly/fixtures/waf_versions/deploy.yaml
@@ -12,7 +12,7 @@ interactions:
       - application/vnd.api+json
       User-Agent:
       - FastlyGo/1.16.0 (+github.com/fastly/go-fastly; go1.14.2)
-    url: https://api.fastly.com/waf/firewalls/5oX1X8cVEBpEXg6PsNSTXA/versions/1/activate
+    url: https://api.fastly.com/waf/firewalls/7kRiB97L3ppEaKv5J3hJmV/versions/1/activate
     method: PUT
   response:
     body: '{}'
@@ -25,7 +25,7 @@ interactions:
       Content-Type:
       - application/vnd.api+json
       Date:
-      - Thu, 02 Jul 2020 20:20:58 GMT
+      - Mon, 06 Jul 2020 11:09:08 GMT
       Status:
       - 202 Accepted
       Strict-Transport-Security:
@@ -40,9 +40,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Served-By:
-      - cache-control-slwdc9035-CONTROL-SLWDC, cache-lcy19265-LCY
+      - cache-control-slwdc9036-CONTROL-SLWDC, cache-lcy19257-LCY
       X-Timer:
-      - S1593721258.140969,VS0,VE151
+      - S1594033748.268765,VS0,VE150
     status: 202 Accepted
     code: 202
     duration: ""

--- a/fastly/fixtures/waf_versions/get.yaml
+++ b/fastly/fixtures/waf_versions/get.yaml
@@ -7,17 +7,17 @@ interactions:
     headers:
       User-Agent:
       - FastlyGo/1.16.0 (+github.com/fastly/go-fastly; go1.14.2)
-    url: https://api.fastly.com/waf/firewalls/5oX1X8cVEBpEXg6PsNSTXA/versions/2
+    url: https://api.fastly.com/waf/firewalls/7kRiB97L3ppEaKv5J3hJmV/versions/2
     method: GET
   response:
-    body: '{"data":{"id":"6q3TBLBKV00lMIsp0DC3wq","type":"waf_firewall_version","attributes":{"active":false,"active_rules_fastly_block_count":0,"active_rules_fastly_log_count":0,"active_rules_owasp_block_count":0,"active_rules_owasp_log_count":0,"active_rules_owasp_score_count":0,"active_rules_trustwave_block_count":0,"active_rules_trustwave_log_count":0,"allowed_http_versions":"HTTP/1.0
-      HTTP/1.1 HTTP/2","allowed_methods":"GET HEAD POST OPTIONS PUT PATCH DELETE","allowed_request_content_type":"application/x-www-form-urlencoded|multipart/form-data|text/xml|application/xml|application/soap+xml|application/x-amf|application/json|application/octet-stream|application/csp-report|application/xss-auditor-report|text/plain","allowed_request_content_type_charset":"utf-8|iso-8859-1|iso-8859-15|windows-1252","arg_name_length":100,"arg_length":400,"combined_file_sizes":10000000,"comment":null,"created_at":"2020-07-02T20:20:58Z","critical_anomaly_score":5,"crs_validate_utf8_encoding":false,"deployed_at":null,"error":null,"error_anomaly_score":4,"high_risk_country_codes":"","http_violation_score_threshold":999,"inbound_anomaly_score_threshold":999,"last_deployment_status":null,"lfi_score_threshold":999,"locked":false,"max_file_size":10000000,"max_num_args":255,"notice_anomaly_score":2,"number":2,"paranoia_level":1,"php_injection_score_threshold":999,"rce_score_threshold":999,"restricted_extensions":".asa/
+    body: '{"data":{"id":"6BowSDK5ezUJMnkXOUWVuD","type":"waf_firewall_version","attributes":{"active":false,"active_rules_fastly_block_count":0,"active_rules_fastly_log_count":0,"active_rules_owasp_block_count":0,"active_rules_owasp_log_count":0,"active_rules_owasp_score_count":0,"active_rules_trustwave_block_count":0,"active_rules_trustwave_log_count":0,"allowed_http_versions":"HTTP/1.0
+      HTTP/1.1 HTTP/2","allowed_methods":"GET HEAD POST OPTIONS PUT PATCH DELETE","allowed_request_content_type":"application/x-www-form-urlencoded|multipart/form-data|text/xml|application/xml|application/soap+xml|application/x-amf|application/json|application/octet-stream|application/csp-report|application/xss-auditor-report|text/plain","allowed_request_content_type_charset":"utf-8|iso-8859-1|iso-8859-15|windows-1252","arg_name_length":100,"arg_length":400,"combined_file_sizes":10000000,"comment":null,"created_at":"2020-07-06T11:09:09Z","critical_anomaly_score":5,"crs_validate_utf8_encoding":false,"deployed_at":null,"error":null,"error_anomaly_score":4,"high_risk_country_codes":"","http_violation_score_threshold":999,"inbound_anomaly_score_threshold":999,"last_deployment_status":null,"lfi_score_threshold":999,"locked":false,"max_file_size":10000000,"max_num_args":255,"notice_anomaly_score":2,"number":2,"paranoia_level":1,"php_injection_score_threshold":999,"rce_score_threshold":999,"restricted_extensions":".asa/
       .asax/ .ascx/ .axd/ .backup/ .bak/ .bat/ .cdx/ .cer/ .cfg/ .cmd/ .com/ .config/
       .conf/ .cs/ .csproj/ .csr/ .dat/ .db/ .dbf/ .dll/ .dos/ .htr/ .htw/ .ida/ .idc/
       .idq/ .inc/ .ini/ .key/ .licx/ .lnk/ .log/ .mdb/ .old/ .pass/ .pdb/ .pol/ .printer/
       .pwd/ .resources/ .resx/ .sql/ .sys/ .vb/ .vbs/ .vbproj/ .vsdisco/ .webinfo/
       .xsd/ .xsx/","restricted_headers":"/proxy/ /lock-token/ /content-range/ /translate/
-      /if/","rfi_score_threshold":999,"session_fixation_score_threshold":999,"sql_injection_score_threshold":999,"total_arg_length":6400,"updated_at":"2020-07-02T20:20:58Z","warning_anomaly_score":3,"xss_score_threshold":999}}}'
+      /if/","rfi_score_threshold":999,"session_fixation_score_threshold":999,"sql_injection_score_threshold":999,"total_arg_length":6400,"updated_at":"2020-07-06T11:09:09Z","warning_anomaly_score":3,"xss_score_threshold":999}}}'
     headers:
       Accept-Ranges:
       - bytes
@@ -31,7 +31,7 @@ interactions:
       Content-Type:
       - application/vnd.api+json
       Date:
-      - Thu, 02 Jul 2020 20:20:59 GMT
+      - Mon, 06 Jul 2020 11:09:10 GMT
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -46,9 +46,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Served-By:
-      - cache-control-slwdc9035-CONTROL-SLWDC, cache-lcy19265-LCY
+      - cache-control-slwdc9036-CONTROL-SLWDC, cache-lcy19257-LCY
       X-Timer:
-      - S1593721259.794691,VS0,VE419
+      - S1594033750.030340,VS0,VE160
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/waf_versions/getPostDeploy_0.yaml
+++ b/fastly/fixtures/waf_versions/getPostDeploy_0.yaml
@@ -1,0 +1,55 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - FastlyGo/1.16.0 (+github.com/fastly/go-fastly; go1.14.2)
+    url: https://api.fastly.com/waf/firewalls/7kRiB97L3ppEaKv5J3hJmV/versions/1
+    method: GET
+  response:
+    body: '{"data":{"id":"6adJ5yqgOU9olga76asAr6","type":"waf_firewall_version","attributes":{"active":false,"active_rules_fastly_block_count":0,"active_rules_fastly_log_count":0,"active_rules_owasp_block_count":0,"active_rules_owasp_log_count":0,"active_rules_owasp_score_count":0,"active_rules_trustwave_block_count":0,"active_rules_trustwave_log_count":0,"allowed_http_versions":"HTTP/1.0
+      HTTP/1.1 HTTP/2","allowed_methods":"GET HEAD POST OPTIONS PUT PATCH DELETE","allowed_request_content_type":"application/x-www-form-urlencoded|multipart/form-data|text/xml|application/xml|application/soap+xml|application/x-amf|application/json|application/octet-stream|application/csp-report|application/xss-auditor-report|text/plain","allowed_request_content_type_charset":"utf-8|iso-8859-1|iso-8859-15|windows-1252","arg_name_length":100,"arg_length":400,"combined_file_sizes":10000000,"comment":null,"created_at":"2020-07-06T11:09:07Z","critical_anomaly_score":5,"crs_validate_utf8_encoding":false,"deployed_at":null,"error":null,"error_anomaly_score":4,"high_risk_country_codes":"","http_violation_score_threshold":999,"inbound_anomaly_score_threshold":999,"last_deployment_status":"in
+      progress","lfi_score_threshold":999,"locked":false,"max_file_size":10000000,"max_num_args":255,"notice_anomaly_score":2,"number":1,"paranoia_level":1,"php_injection_score_threshold":999,"rce_score_threshold":999,"restricted_extensions":".asa/
+      .asax/ .ascx/ .axd/ .backup/ .bak/ .bat/ .cdx/ .cer/ .cfg/ .cmd/ .com/ .config/
+      .conf/ .cs/ .csproj/ .csr/ .dat/ .db/ .dbf/ .dll/ .dos/ .htr/ .htw/ .ida/ .idc/
+      .idq/ .inc/ .ini/ .key/ .licx/ .lnk/ .log/ .mdb/ .old/ .pass/ .pdb/ .pol/ .printer/
+      .pwd/ .resources/ .resx/ .sql/ .sys/ .vb/ .vbs/ .vbproj/ .vsdisco/ .webinfo/
+      .xsd/ .xsx/","restricted_headers":"/proxy/ /lock-token/ /content-range/ /translate/
+      /if/","rfi_score_threshold":999,"session_fixation_score_threshold":999,"sql_injection_score_threshold":999,"total_arg_length":6400,"updated_at":"2020-07-06T11:09:08Z","warning_anomaly_score":3,"xss_score_threshold":999}}}'
+    headers:
+      Accept-Ranges:
+      - bytes
+      - bytes
+      - bytes
+      Age:
+      - "0"
+      - "0"
+      Content-Length:
+      - "2039"
+      Content-Type:
+      - application/vnd.api+json
+      Date:
+      - Mon, 06 Jul 2020 11:09:08 GMT
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000
+      Via:
+      - 1.1 varnish
+      - 1.1 varnish
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Content-Type-Options:
+      - nosniff
+      X-Served-By:
+      - cache-control-slwdc9037-CONTROL-SLWDC, cache-lcy19257-LCY
+      X-Timer:
+      - S1594033749.600415,VS0,VE156
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/fastly/fixtures/waf_versions/getPostDeploy_1.yaml
+++ b/fastly/fixtures/waf_versions/getPostDeploy_1.yaml
@@ -1,0 +1,50 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - FastlyGo/1.16.0 (+github.com/fastly/go-fastly; go1.14.2)
+    url: https://api.fastly.com/waf/firewalls/7kRiB97L3ppEaKv5J3hJmV/versions/1
+    method: GET
+  response:
+    body: '{"data":{"id":"6adJ5yqgOU9olga76asAr6","type":"waf_firewall_version","attributes":{"active":true,"active_rules_fastly_block_count":0,"active_rules_fastly_log_count":0,"active_rules_owasp_block_count":0,"active_rules_owasp_log_count":0,"active_rules_owasp_score_count":0,"active_rules_trustwave_block_count":0,"active_rules_trustwave_log_count":0,"allowed_http_versions":"HTTP/1.0
+      HTTP/1.1 HTTP/2","allowed_methods":"GET HEAD POST OPTIONS PUT PATCH DELETE","allowed_request_content_type":"application/x-www-form-urlencoded|multipart/form-data|text/xml|application/xml|application/soap+xml|application/x-amf|application/json|application/octet-stream|application/csp-report|application/xss-auditor-report|text/plain","allowed_request_content_type_charset":"utf-8|iso-8859-1|iso-8859-15|windows-1252","arg_name_length":100,"arg_length":400,"combined_file_sizes":10000000,"comment":null,"created_at":"2020-07-06T11:09:07Z","critical_anomaly_score":5,"crs_validate_utf8_encoding":false,"deployed_at":"2020-07-06T11:09:08Z","error":null,"error_anomaly_score":4,"high_risk_country_codes":"","http_violation_score_threshold":999,"inbound_anomaly_score_threshold":999,"last_deployment_status":"completed","lfi_score_threshold":999,"locked":true,"max_file_size":10000000,"max_num_args":255,"notice_anomaly_score":2,"number":1,"paranoia_level":1,"php_injection_score_threshold":999,"rce_score_threshold":999,"restricted_extensions":".asa/
+      .asax/ .ascx/ .axd/ .backup/ .bak/ .bat/ .cdx/ .cer/ .cfg/ .cmd/ .com/ .config/
+      .conf/ .cs/ .csproj/ .csr/ .dat/ .db/ .dbf/ .dll/ .dos/ .htr/ .htw/ .ida/ .idc/
+      .idq/ .inc/ .ini/ .key/ .licx/ .lnk/ .log/ .mdb/ .old/ .pass/ .pdb/ .pol/ .printer/
+      .pwd/ .resources/ .resx/ .sql/ .sys/ .vb/ .vbs/ .vbproj/ .vsdisco/ .webinfo/
+      .xsd/ .xsx/","restricted_headers":"/proxy/ /lock-token/ /content-range/ /translate/
+      /if/","rfi_score_threshold":999,"session_fixation_score_threshold":999,"sql_injection_score_threshold":999,"total_arg_length":6400,"updated_at":"2020-07-06T11:09:08Z","warning_anomaly_score":3,"xss_score_threshold":999}}}'
+    headers:
+      Accept-Ranges:
+      - bytes
+      - bytes
+      Content-Length:
+      - "2053"
+      Content-Type:
+      - application/vnd.api+json
+      Date:
+      - Mon, 06 Jul 2020 11:09:09 GMT
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000
+      Via:
+      - 1.1 varnish
+      - 1.1 varnish
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Content-Type-Options:
+      - nosniff
+      X-Served-By:
+      - cache-control-slwdc9036-CONTROL-SLWDC, cache-lcy19257-LCY
+      X-Timer:
+      - S1594033749.441229,VS0,VE161
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/fastly/fixtures/waf_versions/list.yaml
+++ b/fastly/fixtures/waf_versions/list.yaml
@@ -7,17 +7,17 @@ interactions:
     headers:
       User-Agent:
       - FastlyGo/1.16.0 (+github.com/fastly/go-fastly; go1.14.2)
-    url: https://api.fastly.com/waf/firewalls/5oX1X8cVEBpEXg6PsNSTXA/versions
+    url: https://api.fastly.com/waf/firewalls/7kRiB97L3ppEaKv5J3hJmV/versions
     method: GET
   response:
-    body: '{"data":[{"id":"6oTvCXk15i1OiTbir1LNYn","type":"waf_firewall_version","attributes":{"active":false,"active_rules_fastly_block_count":0,"active_rules_fastly_log_count":0,"active_rules_owasp_block_count":0,"active_rules_owasp_log_count":0,"active_rules_owasp_score_count":0,"active_rules_trustwave_block_count":0,"active_rules_trustwave_log_count":0,"allowed_http_versions":"HTTP/1.0
-      HTTP/1.1 HTTP/2","allowed_methods":"GET HEAD POST OPTIONS PUT PATCH DELETE","allowed_request_content_type":"application/x-www-form-urlencoded|multipart/form-data|text/xml|application/xml|application/soap+xml|application/x-amf|application/json|application/octet-stream|application/csp-report|application/xss-auditor-report|text/plain","allowed_request_content_type_charset":"utf-8|iso-8859-1|iso-8859-15|windows-1252","arg_name_length":100,"arg_length":400,"combined_file_sizes":10000000,"comment":null,"created_at":"2020-07-02T20:20:57Z","critical_anomaly_score":5,"crs_validate_utf8_encoding":false,"deployed_at":null,"error":null,"error_anomaly_score":4,"high_risk_country_codes":"","http_violation_score_threshold":999,"inbound_anomaly_score_threshold":999,"last_deployment_status":null,"lfi_score_threshold":999,"locked":false,"max_file_size":10000000,"max_num_args":255,"notice_anomaly_score":2,"number":1,"paranoia_level":1,"php_injection_score_threshold":999,"rce_score_threshold":999,"restricted_extensions":".asa/
+    body: '{"data":[{"id":"6adJ5yqgOU9olga76asAr6","type":"waf_firewall_version","attributes":{"active":false,"active_rules_fastly_block_count":0,"active_rules_fastly_log_count":0,"active_rules_owasp_block_count":0,"active_rules_owasp_log_count":0,"active_rules_owasp_score_count":0,"active_rules_trustwave_block_count":0,"active_rules_trustwave_log_count":0,"allowed_http_versions":"HTTP/1.0
+      HTTP/1.1 HTTP/2","allowed_methods":"GET HEAD POST OPTIONS PUT PATCH DELETE","allowed_request_content_type":"application/x-www-form-urlencoded|multipart/form-data|text/xml|application/xml|application/soap+xml|application/x-amf|application/json|application/octet-stream|application/csp-report|application/xss-auditor-report|text/plain","allowed_request_content_type_charset":"utf-8|iso-8859-1|iso-8859-15|windows-1252","arg_name_length":100,"arg_length":400,"combined_file_sizes":10000000,"comment":null,"created_at":"2020-07-06T11:09:07Z","critical_anomaly_score":5,"crs_validate_utf8_encoding":false,"deployed_at":null,"error":null,"error_anomaly_score":4,"high_risk_country_codes":"","http_violation_score_threshold":999,"inbound_anomaly_score_threshold":999,"last_deployment_status":null,"lfi_score_threshold":999,"locked":false,"max_file_size":10000000,"max_num_args":255,"notice_anomaly_score":2,"number":1,"paranoia_level":1,"php_injection_score_threshold":999,"rce_score_threshold":999,"restricted_extensions":".asa/
       .asax/ .ascx/ .axd/ .backup/ .bak/ .bat/ .cdx/ .cer/ .cfg/ .cmd/ .com/ .config/
       .conf/ .cs/ .csproj/ .csr/ .dat/ .db/ .dbf/ .dll/ .dos/ .htr/ .htw/ .ida/ .idc/
       .idq/ .inc/ .ini/ .key/ .licx/ .lnk/ .log/ .mdb/ .old/ .pass/ .pdb/ .pol/ .printer/
       .pwd/ .resources/ .resx/ .sql/ .sys/ .vb/ .vbs/ .vbproj/ .vsdisco/ .webinfo/
       .xsd/ .xsx/","restricted_headers":"/proxy/ /lock-token/ /content-range/ /translate/
-      /if/","rfi_score_threshold":999,"session_fixation_score_threshold":999,"sql_injection_score_threshold":999,"total_arg_length":6400,"updated_at":"2020-07-02T20:20:57Z","warning_anomaly_score":3,"xss_score_threshold":999}}],"links":{"last":"https://api.fastly.com/waf/firewalls/5oX1X8cVEBpEXg6PsNSTXA/versions?page[number]=1\u0026page[size]=100","first":"https://api.fastly.com/waf/firewalls/5oX1X8cVEBpEXg6PsNSTXA/versions?page[number]=1\u0026page[size]=100"},"meta":{"current_page":1,"per_page":100,"record_count":1,"total_pages":1}}'
+      /if/","rfi_score_threshold":999,"session_fixation_score_threshold":999,"sql_injection_score_threshold":999,"total_arg_length":6400,"updated_at":"2020-07-06T11:09:07Z","warning_anomaly_score":3,"xss_score_threshold":999}}],"links":{"last":"https://api.fastly.com/waf/firewalls/7kRiB97L3ppEaKv5J3hJmV/versions?page[number]=1\u0026page[size]=100","first":"https://api.fastly.com/waf/firewalls/7kRiB97L3ppEaKv5J3hJmV/versions?page[number]=1\u0026page[size]=100"},"meta":{"current_page":1,"per_page":100,"record_count":1,"total_pages":1}}'
     headers:
       Accept-Ranges:
       - bytes
@@ -31,7 +31,7 @@ interactions:
       Content-Type:
       - application/vnd.api+json
       Date:
-      - Thu, 02 Jul 2020 20:20:58 GMT
+      - Mon, 06 Jul 2020 11:09:08 GMT
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -46,9 +46,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Served-By:
-      - cache-control-slwdc9037-CONTROL-SLWDC, cache-lcy19265-LCY
+      - cache-control-slwdc9036-CONTROL-SLWDC, cache-lcy19257-LCY
       X-Timer:
-      - S1593721258.886149,VS0,VE163
+      - S1594033748.743478,VS0,VE397
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/waf_versions/list_all.yaml
+++ b/fastly/fixtures/waf_versions/list_all.yaml
@@ -7,21 +7,21 @@ interactions:
     headers:
       User-Agent:
       - FastlyGo/1.16.0 (+github.com/fastly/go-fastly; go1.14.2)
-    url: https://api.fastly.com/waf/firewalls/5oX1X8cVEBpEXg6PsNSTXA/versions?page%5Bnumber%5D=1&page%5Bsize%5D=100
+    url: https://api.fastly.com/waf/firewalls/7kRiB97L3ppEaKv5J3hJmV/versions?page%5Bnumber%5D=1&page%5Bsize%5D=100
     method: GET
   response:
-    body: '{"data":[{"id":"6q3TBLBKV00lMIsp0DC3wq","type":"waf_firewall_version","attributes":{"active":false,"active_rules_fastly_block_count":0,"active_rules_fastly_log_count":0,"active_rules_owasp_block_count":0,"active_rules_owasp_log_count":0,"active_rules_owasp_score_count":0,"active_rules_trustwave_block_count":0,"active_rules_trustwave_log_count":0,"allowed_http_versions":"HTTP/1.0
+    body: '{"data":[{"id":"6BowSDK5ezUJMnkXOUWVuD","type":"waf_firewall_version","attributes":{"active":false,"active_rules_fastly_block_count":0,"active_rules_fastly_log_count":0,"active_rules_owasp_block_count":0,"active_rules_owasp_log_count":0,"active_rules_owasp_score_count":0,"active_rules_trustwave_block_count":0,"active_rules_trustwave_log_count":0,"allowed_http_versions":"HTTP/1.0
       HTTP/1.1","allowed_methods":"GET HEAD POST","allowed_request_content_type":"application/x-www-form-urlencoded|multipart/form-data|text/xml|application/xml","allowed_request_content_type_charset":"utf-8|iso-8859-1","arg_name_length":200,"arg_length":800,"combined_file_sizes":20000000,"comment":"my
-      comment","created_at":"2020-07-02T20:20:58Z","critical_anomaly_score":12,"crs_validate_utf8_encoding":true,"deployed_at":null,"error":null,"error_anomaly_score":10,"high_risk_country_codes":"gb","http_violation_score_threshold":20,"inbound_anomaly_score_threshold":20,"last_deployment_status":null,"lfi_score_threshold":20,"locked":true,"max_file_size":20000000,"max_num_args":510,"notice_anomaly_score":8,"number":2,"paranoia_level":2,"php_injection_score_threshold":20,"rce_score_threshold":20,"restricted_extensions":".asa/
+      comment","created_at":"2020-07-06T11:09:09Z","critical_anomaly_score":12,"crs_validate_utf8_encoding":true,"deployed_at":null,"error":null,"error_anomaly_score":10,"high_risk_country_codes":"gb","http_violation_score_threshold":20,"inbound_anomaly_score_threshold":20,"last_deployment_status":null,"lfi_score_threshold":20,"locked":true,"max_file_size":20000000,"max_num_args":510,"notice_anomaly_score":8,"number":2,"paranoia_level":2,"php_injection_score_threshold":20,"rce_score_threshold":20,"restricted_extensions":".asa/
       .asax/ .ascx/ .axd/ .backup/ .bak/ .bat/ .cdx/ .cer/ .cfg/ .cmd/ .com/","restricted_headers":"/proxy/
-      /lock-token/","rfi_score_threshold":20,"session_fixation_score_threshold":20,"sql_injection_score_threshold":20,"total_arg_length":12800,"updated_at":"2020-07-02T20:20:59Z","warning_anomaly_score":20,"xss_score_threshold":20}},{"id":"6oTvCXk15i1OiTbir1LNYn","type":"waf_firewall_version","attributes":{"active":true,"active_rules_fastly_block_count":0,"active_rules_fastly_log_count":0,"active_rules_owasp_block_count":0,"active_rules_owasp_log_count":0,"active_rules_owasp_score_count":0,"active_rules_trustwave_block_count":0,"active_rules_trustwave_log_count":0,"allowed_http_versions":"HTTP/1.0
-      HTTP/1.1 HTTP/2","allowed_methods":"GET HEAD POST OPTIONS PUT PATCH DELETE","allowed_request_content_type":"application/x-www-form-urlencoded|multipart/form-data|text/xml|application/xml|application/soap+xml|application/x-amf|application/json|application/octet-stream|application/csp-report|application/xss-auditor-report|text/plain","allowed_request_content_type_charset":"utf-8|iso-8859-1|iso-8859-15|windows-1252","arg_name_length":100,"arg_length":400,"combined_file_sizes":10000000,"comment":null,"created_at":"2020-07-02T20:20:57Z","critical_anomaly_score":5,"crs_validate_utf8_encoding":false,"deployed_at":"2020-07-02T20:20:58Z","error":null,"error_anomaly_score":4,"high_risk_country_codes":"","http_violation_score_threshold":999,"inbound_anomaly_score_threshold":999,"last_deployment_status":"completed","lfi_score_threshold":999,"locked":true,"max_file_size":10000000,"max_num_args":255,"notice_anomaly_score":2,"number":1,"paranoia_level":1,"php_injection_score_threshold":999,"rce_score_threshold":999,"restricted_extensions":".asa/
+      /lock-token/","rfi_score_threshold":20,"session_fixation_score_threshold":20,"sql_injection_score_threshold":20,"total_arg_length":12800,"updated_at":"2020-07-06T11:09:10Z","warning_anomaly_score":20,"xss_score_threshold":20}},{"id":"6adJ5yqgOU9olga76asAr6","type":"waf_firewall_version","attributes":{"active":true,"active_rules_fastly_block_count":0,"active_rules_fastly_log_count":0,"active_rules_owasp_block_count":0,"active_rules_owasp_log_count":0,"active_rules_owasp_score_count":0,"active_rules_trustwave_block_count":0,"active_rules_trustwave_log_count":0,"allowed_http_versions":"HTTP/1.0
+      HTTP/1.1 HTTP/2","allowed_methods":"GET HEAD POST OPTIONS PUT PATCH DELETE","allowed_request_content_type":"application/x-www-form-urlencoded|multipart/form-data|text/xml|application/xml|application/soap+xml|application/x-amf|application/json|application/octet-stream|application/csp-report|application/xss-auditor-report|text/plain","allowed_request_content_type_charset":"utf-8|iso-8859-1|iso-8859-15|windows-1252","arg_name_length":100,"arg_length":400,"combined_file_sizes":10000000,"comment":null,"created_at":"2020-07-06T11:09:07Z","critical_anomaly_score":5,"crs_validate_utf8_encoding":false,"deployed_at":"2020-07-06T11:09:08Z","error":null,"error_anomaly_score":4,"high_risk_country_codes":"","http_violation_score_threshold":999,"inbound_anomaly_score_threshold":999,"last_deployment_status":"completed","lfi_score_threshold":999,"locked":true,"max_file_size":10000000,"max_num_args":255,"notice_anomaly_score":2,"number":1,"paranoia_level":1,"php_injection_score_threshold":999,"rce_score_threshold":999,"restricted_extensions":".asa/
       .asax/ .ascx/ .axd/ .backup/ .bak/ .bat/ .cdx/ .cer/ .cfg/ .cmd/ .com/ .config/
       .conf/ .cs/ .csproj/ .csr/ .dat/ .db/ .dbf/ .dll/ .dos/ .htr/ .htw/ .ida/ .idc/
       .idq/ .inc/ .ini/ .key/ .licx/ .lnk/ .log/ .mdb/ .old/ .pass/ .pdb/ .pol/ .printer/
       .pwd/ .resources/ .resx/ .sql/ .sys/ .vb/ .vbs/ .vbproj/ .vsdisco/ .webinfo/
       .xsd/ .xsx/","restricted_headers":"/proxy/ /lock-token/ /content-range/ /translate/
-      /if/","rfi_score_threshold":999,"session_fixation_score_threshold":999,"sql_injection_score_threshold":999,"total_arg_length":6400,"updated_at":"2020-07-02T20:20:58Z","warning_anomaly_score":3,"xss_score_threshold":999}}],"links":{"last":"https://api.fastly.com/waf/firewalls/5oX1X8cVEBpEXg6PsNSTXA/versions?page[number]=1\u0026page[size]=100","first":"https://api.fastly.com/waf/firewalls/5oX1X8cVEBpEXg6PsNSTXA/versions?page[number]=1\u0026page[size]=100"},"meta":{"current_page":1,"per_page":100,"record_count":2,"total_pages":1}}'
+      /if/","rfi_score_threshold":999,"session_fixation_score_threshold":999,"sql_injection_score_threshold":999,"total_arg_length":6400,"updated_at":"2020-07-06T11:09:08Z","warning_anomaly_score":3,"xss_score_threshold":999}}],"links":{"last":"https://api.fastly.com/waf/firewalls/7kRiB97L3ppEaKv5J3hJmV/versions?page[number]=1\u0026page[size]=100","first":"https://api.fastly.com/waf/firewalls/7kRiB97L3ppEaKv5J3hJmV/versions?page[number]=1\u0026page[size]=100"},"meta":{"current_page":1,"per_page":100,"record_count":2,"total_pages":1}}'
     headers:
       Accept-Ranges:
       - bytes
@@ -35,7 +35,7 @@ interactions:
       Content-Type:
       - application/vnd.api+json
       Date:
-      - Thu, 02 Jul 2020 20:21:00 GMT
+      - Mon, 06 Jul 2020 11:09:11 GMT
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -50,9 +50,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Served-By:
-      - cache-control-slwdc9036-CONTROL-SLWDC, cache-lcy19265-LCY
+      - cache-control-slwdc9035-CONTROL-SLWDC, cache-lcy19257-LCY
       X-Timer:
-      - S1593721260.916258,VS0,VE392
+      - S1594033751.890658,VS0,VE459
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/waf_versions/lock.yaml
+++ b/fastly/fixtures/waf_versions/lock.yaml
@@ -12,14 +12,14 @@ interactions:
       - application/vnd.api+json
       User-Agent:
       - FastlyGo/1.16.0 (+github.com/fastly/go-fastly; go1.14.2)
-    url: https://api.fastly.com/waf/firewalls/5oX1X8cVEBpEXg6PsNSTXA/versions/2
+    url: https://api.fastly.com/waf/firewalls/7kRiB97L3ppEaKv5J3hJmV/versions/2
     method: PATCH
   response:
-    body: '{"data":{"id":"6q3TBLBKV00lMIsp0DC3wq","type":"waf_firewall_version","attributes":{"active":false,"active_rules_fastly_block_count":0,"active_rules_fastly_log_count":0,"active_rules_owasp_block_count":0,"active_rules_owasp_log_count":0,"active_rules_owasp_score_count":0,"active_rules_trustwave_block_count":0,"active_rules_trustwave_log_count":0,"allowed_http_versions":"HTTP/1.0
+    body: '{"data":{"id":"6BowSDK5ezUJMnkXOUWVuD","type":"waf_firewall_version","attributes":{"active":false,"active_rules_fastly_block_count":0,"active_rules_fastly_log_count":0,"active_rules_owasp_block_count":0,"active_rules_owasp_log_count":0,"active_rules_owasp_score_count":0,"active_rules_trustwave_block_count":0,"active_rules_trustwave_log_count":0,"allowed_http_versions":"HTTP/1.0
       HTTP/1.1","allowed_methods":"GET HEAD POST","allowed_request_content_type":"application/x-www-form-urlencoded|multipart/form-data|text/xml|application/xml","allowed_request_content_type_charset":"utf-8|iso-8859-1","arg_name_length":200,"arg_length":800,"combined_file_sizes":20000000,"comment":"my
-      comment","created_at":"2020-07-02T20:20:58Z","critical_anomaly_score":12,"crs_validate_utf8_encoding":true,"deployed_at":null,"error":null,"error_anomaly_score":10,"high_risk_country_codes":"gb","http_violation_score_threshold":20,"inbound_anomaly_score_threshold":20,"last_deployment_status":null,"lfi_score_threshold":20,"locked":true,"max_file_size":20000000,"max_num_args":510,"notice_anomaly_score":8,"number":2,"paranoia_level":2,"php_injection_score_threshold":20,"rce_score_threshold":20,"restricted_extensions":".asa/
+      comment","created_at":"2020-07-06T11:09:09Z","critical_anomaly_score":12,"crs_validate_utf8_encoding":true,"deployed_at":null,"error":null,"error_anomaly_score":10,"high_risk_country_codes":"gb","http_violation_score_threshold":20,"inbound_anomaly_score_threshold":20,"last_deployment_status":null,"lfi_score_threshold":20,"locked":true,"max_file_size":20000000,"max_num_args":510,"notice_anomaly_score":8,"number":2,"paranoia_level":2,"php_injection_score_threshold":20,"rce_score_threshold":20,"restricted_extensions":".asa/
       .asax/ .ascx/ .axd/ .backup/ .bak/ .bat/ .cdx/ .cer/ .cfg/ .cmd/ .com/","restricted_headers":"/proxy/
-      /lock-token/","rfi_score_threshold":20,"session_fixation_score_threshold":20,"sql_injection_score_threshold":20,"total_arg_length":12800,"updated_at":"2020-07-02T20:20:59Z","warning_anomaly_score":20,"xss_score_threshold":20},"relationships":{"waf_firewall":{"data":{"id":"5oX1X8cVEBpEXg6PsNSTXA","type":"waf_firewall"}}}}}'
+      /lock-token/","rfi_score_threshold":20,"session_fixation_score_threshold":20,"sql_injection_score_threshold":20,"total_arg_length":12800,"updated_at":"2020-07-06T11:09:10Z","warning_anomaly_score":20,"xss_score_threshold":20},"relationships":{"waf_firewall":{"data":{"id":"7kRiB97L3ppEaKv5J3hJmV","type":"waf_firewall"}}}}}'
     headers:
       Accept-Ranges:
       - bytes
@@ -29,7 +29,7 @@ interactions:
       Content-Type:
       - application/vnd.api+json
       Date:
-      - Thu, 02 Jul 2020 20:20:59 GMT
+      - Mon, 06 Jul 2020 11:09:10 GMT
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -44,9 +44,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Served-By:
-      - cache-control-slwdc9037-CONTROL-SLWDC, cache-lcy19265-LCY
+      - cache-control-slwdc9036-CONTROL-SLWDC, cache-lcy19257-LCY
       X-Timer:
-      - S1593721260.560847,VS0,VE167
+      - S1594033751.529078,VS0,VE157
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/waf_versions/logging/create.yaml
+++ b/fastly/fixtures/waf_versions/logging/create.yaml
@@ -2,10 +2,10 @@
 version: 1
 interactions:
 - request:
-    body: Service=52szbbqIWi1L5bUd4EBKkX&Version=2&address=example.com&format=format&format_version=2&hostname=example.com&message_type=classic&name=test-syslog&port=1234&token=abcd1234
+    body: Service=5GZsX83POn5zij6allCOKe&Version=2&address=example.com&format=format&format_version=2&hostname=example.com&message_type=classic&name=test-syslog&port=1234&token=abcd1234
     form:
       Service:
-      - 52szbbqIWi1L5bUd4EBKkX
+      - 5GZsX83POn5zij6allCOKe
       Version:
       - "2"
       address:
@@ -29,10 +29,10 @@ interactions:
       - application/x-www-form-urlencoded
       User-Agent:
       - FastlyGo/1.16.0 (+github.com/fastly/go-fastly; go1.14.2)
-    url: https://api.fastly.com/service/52szbbqIWi1L5bUd4EBKkX/version/2/logging/syslog
+    url: https://api.fastly.com/service/5GZsX83POn5zij6allCOKe/version/2/logging/syslog
     method: POST
   response:
-    body: '{"address":"example.com","format":"format","format_version":"2","hostname":"example.com","message_type":"classic","name":"test-syslog","port":"1234","token":"abcd1234","service_id":"52szbbqIWi1L5bUd4EBKkX","version":"2","tls_hostname":null,"tls_ca_cert":null,"use_tls":"0","tls_client_key":null,"public_key":null,"deleted_at":null,"placement":null,"tls_client_cert":null,"ipv4":null,"created_at":"2020-07-02T20:20:55Z","response_condition":"","updated_at":"2020-07-02T20:20:55Z"}'
+    body: '{"address":"example.com","format":"format","format_version":"2","hostname":"example.com","message_type":"classic","name":"test-syslog","port":"1234","token":"abcd1234","service_id":"5GZsX83POn5zij6allCOKe","version":"2","tls_client_cert":null,"deleted_at":null,"created_at":"2020-07-06T11:09:05Z","updated_at":"2020-07-06T11:09:05Z","tls_hostname":null,"tls_ca_cert":null,"placement":null,"ipv4":null,"tls_client_key":null,"public_key":null,"use_tls":"0","response_condition":""}'
     headers:
       Accept-Ranges:
       - bytes
@@ -42,11 +42,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Jul 2020 20:20:55 GMT
+      - Mon, 06 Jul 2020 11:09:05 GMT
       Fastly-Ratelimit-Remaining:
-      - "952"
+      - "979"
       Fastly-Ratelimit-Reset:
-      - "1593723600"
+      - "1594036800"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -61,9 +61,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9035-CONTROL-SLWDC, cache-lcy19265-LCY
+      - cache-control-slwdc9037-CONTROL-SLWDC, cache-lcy19257-LCY
       X-Timer:
-      - S1593721255.159701,VS0,VE719
+      - S1594033745.359766,VS0,VE496
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/waf_versions/logging/delete.yaml
+++ b/fastly/fixtures/waf_versions/logging/delete.yaml
@@ -7,7 +7,7 @@ interactions:
     headers:
       User-Agent:
       - FastlyGo/1.16.0 (+github.com/fastly/go-fastly; go1.14.2)
-    url: https://api.fastly.com/service/52szbbqIWi1L5bUd4EBKkX/version/2/logging/syslog/test-syslog
+    url: https://api.fastly.com/service/5GZsX83POn5zij6allCOKe/version/2/logging/syslog/test-syslog
     method: DELETE
   response:
     body: '{"status":"ok"}'
@@ -20,11 +20,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Jul 2020 20:21:02 GMT
+      - Mon, 06 Jul 2020 11:09:13 GMT
       Fastly-Ratelimit-Remaining:
-      - "947"
+      - "974"
       Fastly-Ratelimit-Reset:
-      - "1593723600"
+      - "1594036800"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -39,9 +39,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9035-CONTROL-SLWDC, cache-lcy19265-LCY
+      - cache-control-slwdc9035-CONTROL-SLWDC, cache-lcy19257-LCY
       X-Timer:
-      - S1593721262.118224,VS0,VE245
+      - S1594033753.121374,VS0,VE260
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/waf_versions/response_object/create.yaml
+++ b/fastly/fixtures/waf_versions/response_object/create.yaml
@@ -2,10 +2,10 @@
 version: 1
 interactions:
 - request:
-    body: Service=52szbbqIWi1L5bUd4EBKkX&Version=2&name=WAf_Response&status=403
+    body: Service=5GZsX83POn5zij6allCOKe&Version=2&name=WAf_Response&status=403
     form:
       Service:
-      - 52szbbqIWi1L5bUd4EBKkX
+      - 5GZsX83POn5zij6allCOKe
       Version:
       - "2"
       name:
@@ -17,10 +17,10 @@ interactions:
       - application/x-www-form-urlencoded
       User-Agent:
       - FastlyGo/1.16.0 (+github.com/fastly/go-fastly; go1.14.2)
-    url: https://api.fastly.com/service/52szbbqIWi1L5bUd4EBKkX/version/2/response_object
+    url: https://api.fastly.com/service/5GZsX83POn5zij6allCOKe/version/2/response_object
     method: POST
   response:
-    body: '{"name":"WAf_Response","status":"403","service_id":"52szbbqIWi1L5bUd4EBKkX","version":"2","content":null,"response":"ok","updated_at":"2020-07-02T20:20:56Z","cache_condition":"","created_at":"2020-07-02T20:20:56Z","request_condition":"","deleted_at":null,"content_type":null}'
+    body: '{"name":"WAf_Response","status":"403","service_id":"5GZsX83POn5zij6allCOKe","version":"2","request_condition":"","content_type":null,"created_at":"2020-07-06T11:09:06Z","deleted_at":null,"response":"ok","content":null,"cache_condition":"","updated_at":"2020-07-06T11:09:06Z"}'
     headers:
       Accept-Ranges:
       - bytes
@@ -30,11 +30,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Jul 2020 20:20:56 GMT
+      - Mon, 06 Jul 2020 11:09:06 GMT
       Fastly-Ratelimit-Remaining:
-      - "950"
+      - "977"
       Fastly-Ratelimit-Reset:
-      - "1593723600"
+      - "1594036800"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -49,9 +49,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9035-CONTROL-SLWDC, cache-lcy19265-LCY
+      - cache-control-slwdc9036-CONTROL-SLWDC, cache-lcy19257-LCY
       X-Timer:
-      - S1593721256.343174,VS0,VE213
+      - S1594033746.319287,VS0,VE242
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/waf_versions/response_object/delete.yaml
+++ b/fastly/fixtures/waf_versions/response_object/delete.yaml
@@ -7,7 +7,7 @@ interactions:
     headers:
       User-Agent:
       - FastlyGo/1.16.0 (+github.com/fastly/go-fastly; go1.14.2)
-    url: https://api.fastly.com/service/52szbbqIWi1L5bUd4EBKkX/version/2/response_object/WAf_Response
+    url: https://api.fastly.com/service/5GZsX83POn5zij6allCOKe/version/2/response_object/WAf_Response
     method: DELETE
   response:
     body: '{"status":"ok"}'
@@ -20,11 +20,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Jul 2020 20:21:01 GMT
+      - Mon, 06 Jul 2020 11:09:12 GMT
       Fastly-Ratelimit-Remaining:
-      - "949"
+      - "976"
       Fastly-Ratelimit-Reset:
-      - "1593723600"
+      - "1594036800"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -39,9 +39,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9037-CONTROL-SLWDC, cache-lcy19265-LCY
+      - cache-control-slwdc9037-CONTROL-SLWDC, cache-lcy19257-LCY
       X-Timer:
-      - S1593721261.253414,VS0,VE268
+      - S1594033752.264087,VS0,VE236
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/waf_versions/service/create.yaml
+++ b/fastly/fixtures/waf_versions/service/create.yaml
@@ -18,7 +18,7 @@ interactions:
     url: https://api.fastly.com/service
     method: POST
   response:
-    body: '{"customer_id":"WpqWFjTA4lk2N1g0GY2HH","comment":"go-fastly client test","name":"test_service_service3","type":"vcl","created_at":"2020-07-02T20:20:54Z","id":"52szbbqIWi1L5bUd4EBKkX","versions":[{"comment":"","deployed":false,"staging":false,"service_id":"52szbbqIWi1L5bUd4EBKkX","locked":false,"deleted_at":null,"updated_at":"2020-07-02T20:20:54Z","created_at":"2020-07-02T20:20:54Z","number":1,"active":false,"testing":false}],"publish_key":"","deleted_at":null,"updated_at":"2020-07-02T20:20:54Z"}'
+    body: '{"customer_id":"WpqWFjTA4lk2N1g0GY2HH","comment":"go-fastly client test","name":"test_service_service3","type":"vcl","id":"5GZsX83POn5zij6allCOKe","versions":[{"testing":false,"active":false,"service_id":"5GZsX83POn5zij6allCOKe","number":1,"created_at":"2020-07-06T11:09:04Z","updated_at":"2020-07-06T11:09:04Z","deleted_at":null,"locked":false,"deployed":false,"comment":"","staging":false}],"created_at":"2020-07-06T11:09:04Z","publish_key":"","updated_at":"2020-07-06T11:09:04Z","deleted_at":null}'
     headers:
       Accept-Ranges:
       - bytes
@@ -28,11 +28,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Jul 2020 20:20:54 GMT
+      - Mon, 06 Jul 2020 11:09:04 GMT
       Fastly-Ratelimit-Remaining:
-      - "954"
+      - "981"
       Fastly-Ratelimit-Reset:
-      - "1593723600"
+      - "1594036800"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -47,9 +47,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9037-CONTROL-SLWDC, cache-lcy19265-LCY
+      - cache-control-slwdc9037-CONTROL-SLWDC, cache-lcy19257-LCY
       X-Timer:
-      - S1593721254.141906,VS0,VE474
+      - S1594033744.045220,VS0,VE487
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/waf_versions/service/delete.yaml
+++ b/fastly/fixtures/waf_versions/service/delete.yaml
@@ -7,7 +7,7 @@ interactions:
     headers:
       User-Agent:
       - FastlyGo/1.16.0 (+github.com/fastly/go-fastly; go1.14.2)
-    url: https://api.fastly.com/service/52szbbqIWi1L5bUd4EBKkX
+    url: https://api.fastly.com/service/5GZsX83POn5zij6allCOKe
     method: DELETE
   response:
     body: '{"status":"ok"}'
@@ -20,11 +20,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Jul 2020 20:21:02 GMT
+      - Mon, 06 Jul 2020 11:09:14 GMT
       Fastly-Ratelimit-Remaining:
-      - "946"
+      - "973"
       Fastly-Ratelimit-Reset:
-      - "1593723600"
+      - "1594036800"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -39,9 +39,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9037-CONTROL-SLWDC, cache-lcy19265-LCY
+      - cache-control-slwdc9035-CONTROL-SLWDC, cache-lcy19257-LCY
       X-Timer:
-      - S1593721263.555733,VS0,VE231
+      - S1594033754.569065,VS0,VE615
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/waf_versions/service/version.yaml
+++ b/fastly/fixtures/waf_versions/service/version.yaml
@@ -2,19 +2,19 @@
 version: 1
 interactions:
 - request:
-    body: Service=52szbbqIWi1L5bUd4EBKkX
+    body: Service=5GZsX83POn5zij6allCOKe
     form:
       Service:
-      - 52szbbqIWi1L5bUd4EBKkX
+      - 5GZsX83POn5zij6allCOKe
     headers:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
       - FastlyGo/1.16.0 (+github.com/fastly/go-fastly; go1.14.2)
-    url: https://api.fastly.com/service/52szbbqIWi1L5bUd4EBKkX/version
+    url: https://api.fastly.com/service/5GZsX83POn5zij6allCOKe/version
     method: POST
   response:
-    body: '{"service_id":"52szbbqIWi1L5bUd4EBKkX","number":2}'
+    body: '{"service_id":"5GZsX83POn5zij6allCOKe","number":2}'
     headers:
       Accept-Ranges:
       - bytes
@@ -24,11 +24,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Jul 2020 20:20:55 GMT
+      - Mon, 06 Jul 2020 11:09:05 GMT
       Fastly-Ratelimit-Remaining:
-      - "953"
+      - "980"
       Fastly-Ratelimit-Reset:
-      - "1593723600"
+      - "1594036800"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -43,9 +43,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9036-CONTROL-SLWDC, cache-lcy19265-LCY
+      - cache-control-slwdc9035-CONTROL-SLWDC, cache-lcy19257-LCY
       X-Timer:
-      - S1593721255.771073,VS0,VE244
+      - S1594033745.664307,VS0,VE540
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/waf_versions/update.yaml
+++ b/fastly/fixtures/waf_versions/update.yaml
@@ -3,7 +3,7 @@ version: 1
 interactions:
 - request:
     body: |
-      {"data":{"type":"waf_firewall_version","id":"6q3TBLBKV00lMIsp0DC3wq","attributes":{"allowed_http_versions":"HTTP/1.0 HTTP/1.1","allowed_methods":"GET HEAD POST","allowed_request_content_type":"application/x-www-form-urlencoded|multipart/form-data|text/xml|application/xml","allowed_request_content_type_charset":"utf-8|iso-8859-1","arg_length":800,"arg_name_length":200,"combined_file_sizes":20000000,"comment":"my comment","critical_anomaly_score":12,"crs_validate_utf8_encoding":true,"error_anomaly_score":10,"high_risk_country_codes":"gb","http_violation_score_threshold":20,"inbound_anomaly_score_threshold":20,"lfi_score_threshold":20,"max_file_size":20000000,"max_num_args":510,"notice_anomaly_score":8,"paranoia_level":2,"php_injection_score_threshold":20,"rce_score_threshold":20,"restricted_extensions":".asa/ .asax/ .ascx/ .axd/ .backup/ .bak/ .bat/ .cdx/ .cer/ .cfg/ .cmd/ .com/","restricted_headers":"/proxy/ /lock-token/","rfi_score_threshold":20,"session_fixation_score_threshold":20,"sql_injection_score_threshold":20,"total_arg_length":12800,"warning_anomaly_score":20,"xss_score_threshold":20}}}
+      {"data":{"type":"waf_firewall_version","id":"6BowSDK5ezUJMnkXOUWVuD","attributes":{"allowed_http_versions":"HTTP/1.0 HTTP/1.1","allowed_methods":"GET HEAD POST","allowed_request_content_type":"application/x-www-form-urlencoded|multipart/form-data|text/xml|application/xml","allowed_request_content_type_charset":"utf-8|iso-8859-1","arg_length":800,"arg_name_length":200,"combined_file_sizes":20000000,"comment":"my comment","critical_anomaly_score":12,"crs_validate_utf8_encoding":true,"error_anomaly_score":10,"high_risk_country_codes":"gb","http_violation_score_threshold":20,"inbound_anomaly_score_threshold":20,"lfi_score_threshold":20,"max_file_size":20000000,"max_num_args":510,"notice_anomaly_score":8,"paranoia_level":2,"php_injection_score_threshold":20,"rce_score_threshold":20,"restricted_extensions":".asa/ .asax/ .ascx/ .axd/ .backup/ .bak/ .bat/ .cdx/ .cer/ .cfg/ .cmd/ .com/","restricted_headers":"/proxy/ /lock-token/","rfi_score_threshold":20,"session_fixation_score_threshold":20,"sql_injection_score_threshold":20,"total_arg_length":12800,"warning_anomaly_score":20,"xss_score_threshold":20}}}
     form: {}
     headers:
       Accept:
@@ -12,14 +12,14 @@ interactions:
       - application/vnd.api+json
       User-Agent:
       - FastlyGo/1.16.0 (+github.com/fastly/go-fastly; go1.14.2)
-    url: https://api.fastly.com/waf/firewalls/5oX1X8cVEBpEXg6PsNSTXA/versions/2
+    url: https://api.fastly.com/waf/firewalls/7kRiB97L3ppEaKv5J3hJmV/versions/2
     method: PATCH
   response:
-    body: '{"data":{"id":"6q3TBLBKV00lMIsp0DC3wq","type":"waf_firewall_version","attributes":{"active":false,"active_rules_fastly_block_count":0,"active_rules_fastly_log_count":0,"active_rules_owasp_block_count":0,"active_rules_owasp_log_count":0,"active_rules_owasp_score_count":0,"active_rules_trustwave_block_count":0,"active_rules_trustwave_log_count":0,"allowed_http_versions":"HTTP/1.0
+    body: '{"data":{"id":"6BowSDK5ezUJMnkXOUWVuD","type":"waf_firewall_version","attributes":{"active":false,"active_rules_fastly_block_count":0,"active_rules_fastly_log_count":0,"active_rules_owasp_block_count":0,"active_rules_owasp_log_count":0,"active_rules_owasp_score_count":0,"active_rules_trustwave_block_count":0,"active_rules_trustwave_log_count":0,"allowed_http_versions":"HTTP/1.0
       HTTP/1.1","allowed_methods":"GET HEAD POST","allowed_request_content_type":"application/x-www-form-urlencoded|multipart/form-data|text/xml|application/xml","allowed_request_content_type_charset":"utf-8|iso-8859-1","arg_name_length":200,"arg_length":800,"combined_file_sizes":20000000,"comment":"my
-      comment","created_at":"2020-07-02T20:20:58Z","critical_anomaly_score":12,"crs_validate_utf8_encoding":true,"deployed_at":null,"error":null,"error_anomaly_score":10,"high_risk_country_codes":"gb","http_violation_score_threshold":20,"inbound_anomaly_score_threshold":20,"last_deployment_status":null,"lfi_score_threshold":20,"locked":false,"max_file_size":20000000,"max_num_args":510,"notice_anomaly_score":8,"number":2,"paranoia_level":2,"php_injection_score_threshold":20,"rce_score_threshold":20,"restricted_extensions":".asa/
+      comment","created_at":"2020-07-06T11:09:09Z","critical_anomaly_score":12,"crs_validate_utf8_encoding":true,"deployed_at":null,"error":null,"error_anomaly_score":10,"high_risk_country_codes":"gb","http_violation_score_threshold":20,"inbound_anomaly_score_threshold":20,"last_deployment_status":null,"lfi_score_threshold":20,"locked":false,"max_file_size":20000000,"max_num_args":510,"notice_anomaly_score":8,"number":2,"paranoia_level":2,"php_injection_score_threshold":20,"rce_score_threshold":20,"restricted_extensions":".asa/
       .asax/ .ascx/ .axd/ .backup/ .bak/ .bat/ .cdx/ .cer/ .cfg/ .cmd/ .com/","restricted_headers":"/proxy/
-      /lock-token/","rfi_score_threshold":20,"session_fixation_score_threshold":20,"sql_injection_score_threshold":20,"total_arg_length":12800,"updated_at":"2020-07-02T20:20:59Z","warning_anomaly_score":20,"xss_score_threshold":20},"relationships":{"waf_firewall":{"data":{"id":"5oX1X8cVEBpEXg6PsNSTXA","type":"waf_firewall"}}}}}'
+      /lock-token/","rfi_score_threshold":20,"session_fixation_score_threshold":20,"sql_injection_score_threshold":20,"total_arg_length":12800,"updated_at":"2020-07-06T11:09:10Z","warning_anomaly_score":20,"xss_score_threshold":20},"relationships":{"waf_firewall":{"data":{"id":"7kRiB97L3ppEaKv5J3hJmV","type":"waf_firewall"}}}}}'
     headers:
       Accept-Ranges:
       - bytes
@@ -29,7 +29,7 @@ interactions:
       Content-Type:
       - application/vnd.api+json
       Date:
-      - Thu, 02 Jul 2020 20:20:59 GMT
+      - Mon, 06 Jul 2020 11:09:10 GMT
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -44,9 +44,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Served-By:
-      - cache-control-slwdc9035-CONTROL-SLWDC, cache-lcy19265-LCY
+      - cache-control-slwdc9036-CONTROL-SLWDC, cache-lcy19257-LCY
       X-Timer:
-      - S1593721259.289697,VS0,VE140
+      - S1594033750.290024,VS0,VE118
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/waf_versions/waf/create.yaml
+++ b/fastly/fixtures/waf_versions/waf/create.yaml
@@ -3,7 +3,7 @@ version: 1
 interactions:
 - request:
     body: |
-      {"data":{"type":"waf_firewall","attributes":{"prefetch_condition":"WAF_Prefetch","response":"WAf_Response","service_id":"52szbbqIWi1L5bUd4EBKkX","service_version_number":"2"}}}
+      {"data":{"type":"waf_firewall","attributes":{"prefetch_condition":"WAF_Prefetch","response":"WAf_Response","service_id":"5GZsX83POn5zij6allCOKe","service_version_number":"2"}}}
     form: {}
     headers:
       Accept:
@@ -15,7 +15,7 @@ interactions:
     url: https://api.fastly.com/waf/firewalls
     method: POST
   response:
-    body: '{"data":{"id":"5oX1X8cVEBpEXg6PsNSTXA","type":"waf_firewall","attributes":{"active_rules_fastly_block_count":0,"active_rules_fastly_log_count":0,"active_rules_fastly_score_count":0,"active_rules_owasp_block_count":0,"active_rules_owasp_log_count":0,"active_rules_owasp_score_count":0,"active_rules_trustwave_block_count":0,"active_rules_trustwave_log_count":0,"created_at":"2020-07-02T20:20:57Z","disabled":false,"prefetch_condition":"WAF_Prefetch","response":"WAf_Response","service_id":"52szbbqIWi1L5bUd4EBKkX","service_version_number":2,"updated_at":"2020-07-02T20:20:57Z"}}}'
+    body: '{"data":{"id":"7kRiB97L3ppEaKv5J3hJmV","type":"waf_firewall","attributes":{"active_rules_fastly_block_count":0,"active_rules_fastly_log_count":0,"active_rules_fastly_score_count":0,"active_rules_owasp_block_count":0,"active_rules_owasp_log_count":0,"active_rules_owasp_score_count":0,"active_rules_trustwave_block_count":0,"active_rules_trustwave_log_count":0,"created_at":"2020-07-06T11:09:07Z","disabled":false,"prefetch_condition":"WAF_Prefetch","response":"WAf_Response","service_id":"5GZsX83POn5zij6allCOKe","service_version_number":2,"updated_at":"2020-07-06T11:09:07Z"}}}'
     headers:
       Accept-Ranges:
       - bytes
@@ -25,7 +25,7 @@ interactions:
       Content-Type:
       - application/vnd.api+json
       Date:
-      - Thu, 02 Jul 2020 20:20:57 GMT
+      - Mon, 06 Jul 2020 11:09:07 GMT
       Status:
       - 201 Created
       Strict-Transport-Security:
@@ -40,9 +40,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Served-By:
-      - cache-control-slwdc9037-CONTROL-SLWDC, cache-lcy19265-LCY
+      - cache-control-slwdc9035-CONTROL-SLWDC, cache-lcy19257-LCY
       X-Timer:
-      - S1593721257.721769,VS0,VE968
+      - S1594033747.712036,VS0,VE839
     status: 201 Created
     code: 201
     duration: ""

--- a/fastly/fixtures/waf_versions/waf/delete.yaml
+++ b/fastly/fixtures/waf_versions/waf/delete.yaml
@@ -3,7 +3,7 @@ version: 1
 interactions:
 - request:
     body: |
-      {"data":{"type":"waf_firewall","id":"5oX1X8cVEBpEXg6PsNSTXA","attributes":{"service_version_number":"2"}}}
+      {"data":{"type":"waf_firewall","id":"7kRiB97L3ppEaKv5J3hJmV","attributes":{"service_version_number":"2"}}}
     form: {}
     headers:
       Accept:
@@ -12,7 +12,7 @@ interactions:
       - application/vnd.api+json
       User-Agent:
       - FastlyGo/1.16.0 (+github.com/fastly/go-fastly; go1.14.2)
-    url: https://api.fastly.com/waf/firewalls/5oX1X8cVEBpEXg6PsNSTXA
+    url: https://api.fastly.com/waf/firewalls/7kRiB97L3ppEaKv5J3hJmV
     method: DELETE
   response:
     body: ""
@@ -21,7 +21,7 @@ interactions:
       - bytes
       - bytes
       Date:
-      - Thu, 02 Jul 2020 20:21:01 GMT
+      - Mon, 06 Jul 2020 11:09:12 GMT
       Status:
       - 204 No Content
       Strict-Transport-Security:
@@ -36,9 +36,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Served-By:
-      - cache-control-slwdc9035-CONTROL-SLWDC, cache-lcy19265-LCY
+      - cache-control-slwdc9037-CONTROL-SLWDC, cache-lcy19257-LCY
       X-Timer:
-      - S1593721261.790412,VS0,VE281
+      - S1594033752.780170,VS0,VE305
     status: 204 No Content
     code: 204
     duration: ""

--- a/fastly/waf_version.go
+++ b/fastly/waf_version.go
@@ -26,7 +26,7 @@ const (
 	WAFVersionDeploymentStatusPending = "pending"
 
 	// WAFVersionDeploymentStatusInProgress is the string value representing in-progress state for last_deployment_status for a WAF version
-	WAFVersionDeploymentStatusInProgress = "in-progress"
+	WAFVersionDeploymentStatusInProgress = "in progress"
 
 	// WAFVersionDeploymentStatusCompleted is the string value representing completed state for last_deployment_status for a WAF versions
 	WAFVersionDeploymentStatusCompleted = "completed"

--- a/fastly/waf_version.go
+++ b/fastly/waf_version.go
@@ -21,6 +21,18 @@ const (
 
 	// WAFBatchModifyMaximumOperations is used as the default batch maximum operations.
 	WAFBatchModifyMaximumOperations = 500
+
+	// WAFVersionDeploymentStatusPending is the string value representing pending state for last_deployment_status for a WAF version
+	WAFVersionDeploymentStatusPending = "pending"
+
+	// WAFVersionDeploymentStatusInProgress is the string value representing in-progress state for last_deployment_status for a WAF version
+	WAFVersionDeploymentStatusInProgress = "in-progress"
+
+	// WAFVersionDeploymentStatusCompleted is the string value representing completed state for last_deployment_status for a WAF versions
+	WAFVersionDeploymentStatusCompleted = "completed"
+
+	// WAFVersionDeploymentStatusFailed is the string value representing failed state for last_deployment_status for a WAF versions
+	WAFVersionDeploymentStatusFailed = "failed"
 )
 
 // WAFVersion is the information about a WAF version object.
@@ -33,6 +45,7 @@ type WAFVersion struct {
 	CRSValidateUTF8Encoding          bool       `jsonapi:"attr,crs_validate_utf8_encoding"`
 	Comment                          string     `jsonapi:"attr,comment"`
 	Error                            string     `jsonapi:"attr,error"`
+	LastDeploymentStatus             string     `jsonapi:"attr,last_deployment_status"`
 	DeployedAt                       *time.Time `jsonapi:"attr,deployed_at,iso8601"`
 	AllowedHTTPVersions              string     `jsonapi:"attr,allowed_http_versions"`
 	AllowedMethods                   string     `jsonapi:"attr,allowed_methods"`


### PR DESCRIPTION
Fixes: Trello [#1](https://trello.com/c/l3oJbxSh/1-issue-1-async-deployment-in-terraform)

Changes:
 * Adds LastDeploymentStatus to WAFVersion struct to make it available to clients
 * Add consts for values of LastDeploymentStatus

This ports the solutions from opencredo/go-fastly-spike