### PR TITLE
Change TLS certificate `name` attribute to be optional

### DIFF
--- a/fastly/custom_tls_certificate.go
+++ b/fastly/custom_tls_certificate.go
@@ -124,16 +124,13 @@ func (c *Client) GetCustomTLSCertificate(i *GetCustomTLSCertificateInput) (*Cust
 type CreateCustomTLSCertificateInput struct {
 	ID       string `jsonapi:"primary,tls_certificate"` // ID value does not need to be set.
 	CertBlob string `jsonapi:"attr,cert_blob"`
-	Name     string `jsonapi:"attr,name"`
+	Name     string `jsonapi:"attr,name,omitempty"`
 }
 
 // CreateCustomTLSCertificate creates a custom TLS certificate.
 func (c *Client) CreateCustomTLSCertificate(i *CreateCustomTLSCertificateInput) (*CustomTLSCertificate, error) {
 	if i.CertBlob == "" {
 		return nil, ErrMissingCertBlob
-	}
-	if i.Name == "" {
-		return nil, ErrMissingName
 	}
 
 	p := "/tls/certificates"
@@ -155,7 +152,7 @@ func (c *Client) CreateCustomTLSCertificate(i *CreateCustomTLSCertificateInput) 
 type UpdateCustomTLSCertificateInput struct {
 	ID       string `jsonapi:"primary,tls_certificate"`
 	CertBlob string `jsonapi:"attr,cert_blob"`
-	Name     string `jsonapi:"attr,name"`
+	Name     string `jsonapi:"attr,name,omitempty"`
 }
 
 // UpdateCustomTLSCertificate replace a certificate with a newly reissued certificate.
@@ -169,10 +166,6 @@ func (c *Client) UpdateCustomTLSCertificate(i *UpdateCustomTLSCertificateInput) 
 
 	if i.CertBlob == "" {
 		return nil, ErrMissingCertBlob
-	}
-
-	if i.Name == "" {
-		return nil, ErrMissingName
 	}
 
 	path := fmt.Sprintf("/tls/certificates/%s", i.ID)

--- a/fastly/custom_tls_certificate_test.go
+++ b/fastly/custom_tls_certificate_test.go
@@ -106,13 +106,6 @@ func TestClient_CreateCustomTLSCertificate_validation(t *testing.T) {
 	}
 
 	_, err = testClient.CreateCustomTLSCertificate(&CreateCustomTLSCertificateInput{
-		CertBlob: "-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----\n",
-	})
-	if err != ErrMissingName {
-		t.Errorf("bad error: %s", err)
-	}
-
-	_, err = testClient.CreateCustomTLSCertificate(&CreateCustomTLSCertificateInput{
 		Name: "My certificate",
 	})
 	if err != ErrMissingCertBlob {
@@ -198,14 +191,6 @@ func TestClient_UpdateCustomTLSCertificate_validation(t *testing.T) {
 		Name: "My certificate",
 	})
 	if err != ErrMissingCertBlob {
-		t.Errorf("bad error: %s", err)
-	}
-
-	_, err = testClient.UpdateCustomTLSCertificate(&UpdateCustomTLSCertificateInput{
-		ID:       "CERTIFICATE_ID",
-		CertBlob: "-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----\n",
-	})
-	if err != ErrMissingName {
 		t.Errorf("bad error: %s", err)
 	}
 }


### PR DESCRIPTION
Custom TLS certificate without names default to the certificates common name or first SAN entry