### PR TITLE
Get Certificate ID for TLS Subscriptions when available

### DIFF
--- a/fastly/tls_subscription.go
+++ b/fastly/tls_subscription.go
@@ -11,14 +11,19 @@ import (
 
 // TLSSubscription represents a managed TLS certificate
 type TLSSubscription struct {
-	ID                   string               `jsonapi:"primary,tls_subscription"`
-	CertificateAuthority string               `jsonapi:"attr,certificate_authority"`
-	State                string               `jsonapi:"attr,state"`
-	CreatedAt            *time.Time           `jsonapi:"attr,created_at,iso8601"`
-	UpdatedAt            *time.Time           `jsonapi:"attr,updated_at,iso8601"`
-	Configuration        *TLSConfiguration    `jsonapi:"relation,tls_configuration"`
-	TLSDomains           []*TLSDomain         `jsonapi:"relation,tls_domains"`
-	Authorizations       []*TLSAuthorizations `jsonapi:"relation,tls_authorizations"`
+	ID                   string                        `jsonapi:"primary,tls_subscription"`
+	CertificateAuthority string                        `jsonapi:"attr,certificate_authority"`
+	State                string                        `jsonapi:"attr,state"`
+	CreatedAt            *time.Time                    `jsonapi:"attr,created_at,iso8601"`
+	UpdatedAt            *time.Time                    `jsonapi:"attr,updated_at,iso8601"`
+	Configuration        *TLSConfiguration             `jsonapi:"relation,tls_configuration"`
+	TLSDomains           []*TLSDomain                  `jsonapi:"relation,tls_domains"`
+	Certificates         []*TLSSubscriptionCertificate `jsonapi:"relation,tls_certificates"`
+	Authorizations       []*TLSAuthorizations          `jsonapi:"relation,tls_authorizations"`
+}
+
+type TLSSubscriptionCertificate struct {
+	ID string `jsonapi:"primary,tls_certificate"`
 }
 
 type TLSAuthorizations struct {


### PR DESCRIPTION
The subscription's certificate can't really be queried in the same way as the custom TLS certificate, but an associated certificate ID will be present in the TLS activation automatically created for the TLS subscription, so having access to it can help find the activation. This is used in the TF provider's subscription deletion function in order to first delete the activation